### PR TITLE
Small fixes for running locally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ autoflake = "^1.4"
 flake8 = { version = "^4.0.1", optional = true }
 streamlit = "^1.10.0"
 scipy = "^1.8.1"
-pytest-mock = "^3.8.2."
+pytest-mock = "^3.8.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-if docker compose -h >/dev/null; then
+if docker help compose >/dev/null; then
   docker="docker compose"
 else
   docker="docker-compose"

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -2,7 +2,7 @@
 
 set -eu -o pipefail
 
-if docker help compose >/dev/null; then
+if docker help compose &>/dev/null; then
   docker="docker compose"
 else
   docker="docker-compose"


### PR DESCRIPTION
Tiny things I ran into while running/setting up ICE locally:

1. On my Ubuntu machine, `docker compose -h` shows the help for docker and exits with 0, it doesn't care that `compose` doesn't exist as a subcommand. This made `run-local.sh` think that the subcommand existed. On the other hand, `docker help compose` says `unknown help topic: compose` (on stderr) and exits 1, and `docker help run` exits 0. EDIT: just noticed that other scripts simply use `docker compose` without even checking, so the next step will be to make a little reusable helper like `docker-compose.sh` that abstracts this away.
2. `poetry install` gave an error because of a trailing `.` in a version in `pyproject.toml`.