### PR TITLE
allow custom stop tokens for OpenAI answer

### DIFF
--- a/ice/agents/openai.py
+++ b/ice/agents/openai.py
@@ -31,13 +31,14 @@ class OpenAIAgent(Agent):
         prompt: str,
         multiline: bool = True,
         verbose: bool = False,
-        default: str = "",
         max_tokens: int = 256,
+        stop: list[str] = None,
     ) -> str:
-        """Generate an answer to a question given some context."""
+        """Generate a completion given some prompt."""
         if verbose:
             self._print_markdown(prompt)
-        stop = None if multiline else "\n"
+        if stop is None and not multiline:
+            stop = "\n"
         response = await self._complete(prompt, stop=stop, max_tokens=max_tokens)
         answer = self._extract_answer(response)
         if verbose:


### PR DESCRIPTION
As far as I can tell, `answer`  doesn't do any special question/answer formatting, which confused me temporarily, suggest changing the description