### PR TITLE
Delete unnecessary anonymous volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       # When mounting /code, don't clobber generated directories.
       # https://stackoverflow.com/a/37898591
       - /code/.venv/
-      - /code/ui/.next/
       - /code/ui/node_modules/
       - ./:/code
     ports:


### PR DESCRIPTION
This was never needed since `.next/` is generated by `CMD`, not an image layer, and (speculatively) it appears to be [causing problems](https://github.com/oughtinc/ice/issues/42) in certain versions of compose.