### PR TITLE
Pulls through the cache id param for the OpenAI agent

### DIFF
--- a/ice/agents/openai.py
+++ b/ice/agents/openai.py
@@ -39,7 +39,9 @@ class OpenAIAgent(Agent):
         """Generate an answer to a question given some context."""
         if verbose:
             self._print_markdown(prompt)
-        response = await self._complete(prompt, stop=stop, max_tokens=max_tokens, cache_id=cache_id)
+        response = await self._complete(
+            prompt, stop=stop, max_tokens=max_tokens, cache_id=cache_id
+        )
         completion = self._extract_completion(response)
         if verbose:
             self._print_markdown(completion)

--- a/ice/agents/openai.py
+++ b/ice/agents/openai.py
@@ -34,11 +34,12 @@ class OpenAIAgent(Agent):
         verbose: bool = False,
         default: str = "",
         max_tokens: int = 256,
+        cache_id: int = 0,  # for repeated non-deterministic sampling using caching
     ) -> str:
         """Generate an answer to a question given some context."""
         if verbose:
             self._print_markdown(prompt)
-        response = await self._complete(prompt, stop=stop, max_tokens=max_tokens)
+        response = await self._complete(prompt, stop=stop, max_tokens=max_tokens, cache_id=cache_id)
         completion = self._extract_completion(response)
         if verbose:
             self._print_markdown(completion)


### PR DESCRIPTION
Simply pulls through the `cache_id` param from OpenAI completion call through to the OpenAI Agent's completion method. Makes it easier to sample multiple completions by iterating over the cache_id (as per the suggestion to resolving [this issue](https://github.com/oughtinc/ice/issues/62)).