### PR TITLE
Render newlines when rendering docstrings in visualizer

### DIFF
--- a/ui/components/TracePage/TracePage.tsx
+++ b/ui/components/TracePage/TracePage.tsx
@@ -580,9 +580,7 @@ const TabHeader = ({ id, doc }: { id: string; doc: string }) => (
     <h3 className="text-lg font-semibold text-gray-800">
       <CallName id={id} />
     </h3>
-    <p className="text-gray-600 text-sm whitespace-pre-line">
-      {doc}
-    </p>
+    <p className="text-gray-600 text-sm whitespace-pre-line">{doc}</p>
   </div>
 );
 

--- a/ui/components/TracePage/TracePage.tsx
+++ b/ui/components/TracePage/TracePage.tsx
@@ -580,7 +580,7 @@ const TabHeader = ({ id, doc }: { id: string; doc: string }) => (
     <h3 className="text-lg font-semibold text-gray-800">
       <CallName id={id} />
     </h3>
-    <p className="text-gray-600 text-sm" style={{ whiteSpace: "pre-line" }}>
+    <p className="text-gray-600 text-sm whitespace-pre-line">
       {doc}
     </p>
   </div>

--- a/ui/components/TracePage/TracePage.tsx
+++ b/ui/components/TracePage/TracePage.tsx
@@ -580,7 +580,9 @@ const TabHeader = ({ id, doc }: { id: string; doc: string }) => (
     <h3 className="text-lg font-semibold text-gray-800">
       <CallName id={id} />
     </h3>
-    <p className="text-gray-600 text-sm">{doc}</p>
+    <p className="text-gray-600 text-sm" style={{ whiteSpace: "pre-line" }}>
+      {doc}
+    </p>
   </div>
 );
 


### PR DESCRIPTION
We're currently not respecting newlines in docstrings in the visualizer, making them appear run together. This changes that.