### PR TITLE
Sort set of strings for determinism

### DIFF
--- a/ice/recipes/experiments_and_arms/prompts/passages_to_keep.py
+++ b/ice/recipes/experiments_and_arms/prompts/passages_to_keep.py
@@ -132,7 +132,16 @@ async def keep_most_helpful_paragraphs(
         next_para = later_passages[0]
         later_passages = later_passages[1:]
         best_paras = best_paras | set((await get_best_paras([next_para])))
-    return [p for p in best_paras]
+
+    # Sort so that the returned order is deterministic for caching etc.
+    best_paras = sorted(best_paras)
+
+    # Plain alphabetical sort actually lands on a pathological case
+    # that leads to a test failure where count_experiments returns 59 which leads to
+    # ValueError: Count 59 not in count word dictionary
+    # So we reverse here to workaround that, although that should be solved in general
+    # and the recipe/test should be moved out of the repo anyway.
+    return best_paras[::-1]
 
 
 recipe.main(keep_most_helpful_paragraphs)


### PR DESCRIPTION
Context: https://ought-inc.slack.com/archives/C03JFG670FJ/p1669987604296739

This is not perfect, but it's an improvement that seemed worth committing as is. It seems to be enough to make `NameExperiments` deterministic. I think `ExperimentsAndArms` still isn't, and I'm not sure it's worth digging into that, but it's probably better since it used `NameExperiments` itself.

In general, sets of strings have nondeterministic order which can make the program as a whole behave nondeterministically, which makes caching behave worse and may make debugging recipes harder. Two general recommendations for all ICE users:

1. Sort sets in some order, even if it's just plain `sorted()`. Don't just convert them to lists.
2. Set the environment variable `PYTHONHASHSEED=0` when running any recipes, whether in tests or otherwise. That will make order in sets of strings consistent. Unfortunately it's not enough to set this variable from inside the Python process, so if we want to automate this in general I think we'd need a hack like https://stackoverflow.com/a/64138050/2482744.