### PR TITLE
Pass along kwargs in calls to complete()

### DIFF
--- a/ice/agents/base.py
+++ b/ice/agents/base.py
@@ -14,6 +14,7 @@ class Agent(TracedABC):
         verbose: bool = False,
         default: str = "",
         max_tokens: int = 256,
+        **kwargs
     ) -> str:
         raise NotImplementedError
 

--- a/ice/agents/openai.py
+++ b/ice/agents/openai.py
@@ -34,11 +34,12 @@ class OpenAIAgent(Agent):
         verbose: bool = False,
         default: str = "",
         max_tokens: int = 256,
+        **kwargs,
     ) -> str:
         """Generate an answer to a question given some context."""
         if verbose:
             self._print_markdown(prompt)
-        response = await self._complete(prompt, stop=stop, max_tokens=max_tokens)
+        response = await self._complete(prompt, stop=stop, max_tokens=max_tokens, **kwargs)
         completion = self._extract_completion(response)
         if verbose:
             self._print_markdown(completion)


### PR DESCRIPTION
This makes it possible to use the `logit_bias` in `openai_complete` from a call like `recipe.agent().complete(logit_bias=...`

(Happy to architect this another way if preferred)