### PR TITLE
Fix HMR race condition that broke TracePage

### DIFF
--- a/ui/components/TracePage/CallIconButton.tsx
+++ b/ui/components/TracePage/CallIconButton.tsx
@@ -1,30 +1,36 @@
-import { Button } from "@chakra-ui/react";
+import { Button, forwardRef } from "@chakra-ui/react";
 import { CaretDown, CaretRight, ChatCenteredDots } from "phosphor-react";
 
-export const CallIconButton = ({
-  expanded,
-  onChange,
-  childCount,
-  isModelCall,
-}: {
-  expanded: boolean;
-  onChange: (expanded: boolean) => void;
-  childCount: number;
-  isModelCall: boolean;
-}) => (
-  <Button
-    className="rounded-full p-1 h-fit mr-2 !shadow-none hover:bg-slate-200 w-12"
-    isActive={expanded}
-    {...(isModelCall || !childCount
-      ? {}
-      : {
-          "aria-label": expanded ? "Collapse" : "Expand",
-          leftIcon: expanded ? <CaretDown /> : <CaretRight />,
-          onClick: () => onChange(expanded),
-        })}
-    size="md"
-    variant="outline"
-  >
-    <span className="mr-1">{isModelCall ? <ChatCenteredDots /> : childCount || "𝑓"}</span>
-  </Button>
+export const CallIconButton = forwardRef(
+  (
+    {
+      expanded,
+      onChange,
+      childCount,
+      isModelCall,
+    }: {
+      expanded: boolean;
+      onChange: (expanded: boolean) => void;
+      childCount: number;
+      isModelCall: boolean;
+    },
+    ref,
+  ) => (
+    <Button
+      className="rounded-full p-1 h-fit mr-2 !shadow-none hover:bg-slate-200 w-12"
+      isActive={expanded}
+      {...(isModelCall || !childCount
+        ? {}
+        : {
+            "aria-label": expanded ? "Collapse" : "Expand",
+            leftIcon: expanded ? <CaretDown /> : <CaretRight />,
+            onClick: () => onChange(expanded),
+          })}
+      ref={ref}
+      size="md"
+      variant="outline"
+    >
+      <span className="mr-1">{isModelCall ? <ChatCenteredDots /> : childCount || "𝑓"}</span>
+    </Button>
+  ),
 );

--- a/ui/components/TracePage/TracePage.tsx
+++ b/ui/components/TracePage/TracePage.tsx
@@ -159,8 +159,6 @@ const TreeProvider = ({ traceId, children }: { traceId: string; children: ReactN
     }
   }, [autoselected, calls, traceId]);
 
-  const isMounted = useRef(true);
-
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout>;
 
@@ -186,7 +184,6 @@ const TreeProvider = ({ traceId, children }: { traceId: string; children: ReactN
         const { status } = response;
         if (status !== 206) throw new Error(`Unexpected status: ${status}`);
         const text = await response.text();
-        if (!isMounted.current) return;
 
         const end = text.lastIndexOf("\n") + 1;
         traceOffsetRef.current += end;
@@ -201,16 +198,13 @@ const TreeProvider = ({ traceId, children }: { traceId: string; children: ReactN
       } catch (e) {
         console.warn("fetch failed", e);
       } finally {
-        if (isMounted.current) {
-          timeoutId = setTimeout(poll, delay);
-        }
+        timeoutId = setTimeout(poll, delay);
       }
     };
 
     poll();
 
     return () => {
-      isMounted.current = false;
       clearTimeout(timeoutId);
     };
   }, [traceId]);
@@ -259,8 +253,6 @@ const TreeProvider = ({ traceId, children }: { traceId: string; children: ReactN
       // requires both ends of the range to be specified.
       const response = await fetch(url, { headers: { Range: `bytes=${start}-999999999` } });
       const text = await response.text();
-
-      if (!isMounted.current) return;
 
       start += text.length;
       const lines = text.split("\n");


### PR DESCRIPTION
This was caused by isMounted being set to false before the fetch was completed. Since React 18 [got rid of the warning](https://github.com/facebook/react/pull/22114) 
when setState is called on unmounted components, I removed the isMounted checks. This means we do a tiny bit of extra work if the user navigates away from the TracePage right before a fetch completes (which isn't even possible right now), but who cares.

I also fixed a console error, not sure how that snuck in since I could've sworn the console was warnings-clean before now.