### PR TITLE
Summarizing args and results [ICE-11]

### DIFF
--- a/ice/summarize.py
+++ b/ice/summarize.py
@@ -28,6 +28,13 @@ class Summarizer:
             return x
 
     def summarize_dict(self, x: dict[str, JSONValue], depth_left: int):
+        if list(x.keys()) == ["__fstring__"]:
+            new_x = {}
+            for part in x["__fstring__"]:
+                if isinstance(part, dict) and "value" in part:
+                    new_x[part["source"]] = part["value"]
+            x = new_x
+
         result = {}
         for k in sorted(x.keys())[: self.dict_limit]:
             v = self.summarize(x[k], depth_left - 1)

--- a/ice/summarize.py
+++ b/ice/summarize.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from typing import Any
+from typing import cast
 
 from ice.json_value import JSONValue
 
@@ -11,7 +13,7 @@ class Summarizer:
     depth_limit: int = 4
     float_digits: int = 4
 
-    def summarize(self, x: JSONValue, depth_left: int = None):
+    def summarize(self, x: JSONValue, depth_left: int | None = None):
         if depth_left is None:
             depth_left = self.depth_limit
         elif depth_left <= 0:
@@ -30,7 +32,7 @@ class Summarizer:
     def summarize_dict(self, x: dict[str, JSONValue], depth_left: int):
         if list(x.keys()) == ["__fstring__"]:
             new_x = {}
-            for part in x["__fstring__"]:
+            for part in cast(Any, x["__fstring__"]):
                 if isinstance(part, dict) and "value" in part:
                     new_x[part["source"]] = part["value"]
             x = new_x

--- a/ice/summarize.py
+++ b/ice/summarize.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+
+from ice.json_value import JSONValue
+
+
+@dataclass
+class Summarizer:
+    str_limit: int = 100
+    list_limit: int = 3
+    dict_limit: int = 10
+    depth_limit: int = 4
+    float_digits: int = 4
+
+    def summarize(self, x: JSONValue, depth_left: int = None):
+        if depth_left is None:
+            depth_left = self.depth_limit
+        elif depth_left <= 0:
+            return None
+        if isinstance(x, list):
+            return self.summarize_list(x, depth_left)
+        elif isinstance(x, dict):
+            return self.summarize_dict(x, depth_left)
+        elif isinstance(x, str):
+            return self.summarize_str(x)
+        elif isinstance(x, float):
+            return self.summarize_float(x)
+        else:
+            return x
+
+    def summarize_dict(self, x: dict[str, JSONValue], depth_left: int):
+        result = {}
+        for k in sorted(x.keys())[: self.dict_limit]:
+            v = self.summarize(x[k], depth_left - 1)
+            if not self._is_empty(v):
+                result[k] = v
+        return result
+
+    def summarize_list(self, x: list[JSONValue], depth_left: int):
+        result = [self.summarize(v, depth_left - 1) for v in x[: self.list_limit]]
+        while result and self._is_empty(result[-1]):
+            result.pop()
+        return result
+
+    def summarize_str(self, string: str):
+        """
+        Returns a version of `string` at most `self.str_limit` characters long,
+        with the middle replaced by `...` if necessary.
+        """
+        lim = self.str_limit
+        if len(string) > lim:
+            # uncomment to omit long strings entirely instead of truncating
+            # return None
+
+            middle = "..."
+            i = (lim - len(middle)) // 2
+            j = lim - len(middle) - i
+            string = string[:i] + middle + string[-j:]
+        return string
+
+    def summarize_float(self, x: float):
+        # TODO use significant digits instead of decimal places?
+        return round(x, self.float_digits)
+
+    def _is_empty(self, x: JSONValue):
+        return x in ([], {}, "", None)
+
+
+summarize = Summarizer().summarize

--- a/ice/trace.py
+++ b/ice/trace.py
@@ -27,6 +27,7 @@ import ulid
 from structlog import get_logger
 
 from ice.json_value import JSONValue
+from ice.summarize import summarize
 from ice.json_value import to_json_value
 from ice.server import ensure_server_running
 from ice.server import is_server_running
@@ -249,6 +250,7 @@ def trace(fn):
                 start=monotonic_ns(),
                 name=fn.__name__ if hasattr(fn, "__name__") else repr(fn),
                 shortArgs=get_strings(arg_dict_json),
+                argsSummary=summarize(arg_dict_json),
                 func=emit_block(func_info(fn)),
                 args=emit_block(arg_dict_json),
             )
@@ -272,6 +274,7 @@ def trace(fn):
                 {
                     f"{id}.result": emit_block(result_json),
                     f"{id}.shortResult": get_strings(result_json),
+                    f"{id}.resultSummary": summarize(result_json),
                     f"{id}.end": monotonic_ns(),
                 }
             )

--- a/ice/trace.py
+++ b/ice/trace.py
@@ -27,13 +27,13 @@ import ulid
 from structlog import get_logger
 
 from ice.json_value import JSONValue
-from ice.summarize import summarize
 from ice.json_value import to_json_value
 from ice.server import ensure_server_running
 from ice.server import is_server_running
 from ice.settings import OUGHT_ICE_DIR
 from ice.settings import server_url
 from ice.settings import settings
+from ice.summarize import summarize
 
 log = get_logger()
 

--- a/ice/trace.py
+++ b/ice/trace.py
@@ -33,7 +33,6 @@ from ice.server import is_server_running
 from ice.settings import OUGHT_ICE_DIR
 from ice.settings import server_url
 from ice.settings import settings
-from ice.summarize import summarize
 
 log = get_logger()
 
@@ -250,7 +249,6 @@ def trace(fn):
                 start=monotonic_ns(),
                 name=fn.__name__ if hasattr(fn, "__name__") else repr(fn),
                 shortArgs=get_strings(arg_dict_json),
-                argsSummary=summarize(arg_dict_json),
                 func=emit_block(func_info(fn)),
                 args=emit_block(arg_dict_json),
             )
@@ -274,7 +272,6 @@ def trace(fn):
                 {
                     f"{id}.result": emit_block(result_json),
                     f"{id}.shortResult": get_strings(result_json),
-                    f"{id}.resultSummary": summarize(result_json),
                     f"{id}.end": monotonic_ns(),
                 }
             )

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -16,3 +16,60 @@ def test_f():
     assert summarize(to_json_value(f)) == {"name": "world"}
     f += "!"
     assert summarize(to_json_value(f)) == {"f": {"name": "world"}}
+
+
+def test_basic():
+    assert summarize(list(range(10))) == [0, 1, 2]
+    assert summarize(dict(enumerate(range(100)))) == {
+        0: 0,
+        1: 1,
+        2: 2,
+        3: 3,
+        4: 4,
+        5: 5,
+        6: 6,
+        7: 7,
+        8: 8,
+        9: 9,
+    }
+    assert (
+        summarize("abc" * 100)
+        == "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc...cabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc"
+    )
+
+
+def test_depth():
+    assert summarize({"a": {"b": {"c": 3}}}) == {
+        "a": {
+            "b": {
+                "c": 3,
+            }
+        }
+    }
+    assert (
+        summarize(
+            {
+                "a": {
+                    "b": {
+                        "c": {
+                            "d": 3,
+                        }
+                    }
+                }
+            }
+        )
+        == {}
+    )
+    assert summarize({"a": {"b": {"c": {"d": 3}, "e": 4}}}) == {
+        "a": {
+            "b": {
+                "e": 4,
+            },
+        }
+    }
+
+
+def test_empty():
+    assert summarize({"a": "b", "c": None, "d": {}, "e": [], "f": ""}) == {
+        "a": "b",
+    }

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -73,3 +73,35 @@ def test_empty():
     assert summarize({"a": "b", "c": None, "d": {}, "e": [], "f": ""}) == {
         "a": "b",
     }
+
+
+def test_complex():
+    assert summarize(
+        {
+            "a": {
+                "b": [1, 2, 3, 4, 5],
+                "c": {
+                    "d": "abc" * 100,
+                    "e": 1.23456789,
+                },
+            },
+            "f": None,
+            "g": {
+                "h": {
+                    "i": {
+                        "j": {
+                            "k": "hello",
+                        }
+                    }
+                }
+            },
+        }
+    ) == {
+        "a": {
+            "b": [1, 2, 3],
+            "c": {
+                "d": "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc...cabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc",
+                "e": 1.2346,
+            },
+        }
+    }

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -20,7 +20,8 @@ def test_f():
 
 def test_basic():
     assert summarize(list(range(10))) == [0, 1, 2]
-    assert summarize(dict(enumerate(range(100)))) == {
+    d: dict = dict(enumerate(range(100)))
+    assert summarize(d) == {
         0: 0,
         1: 1,
         2: 2,

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -1,0 +1,18 @@
+from fvalues import F
+
+from ice.json_value import to_json_value
+from ice.summarize import summarize
+
+
+def test_f():
+    name = "world"
+    f = F(f"hello {name}")
+    assert to_json_value(f) == {
+        "__fstring__": [
+            "hello ",
+            {"source": "name", "value": "world", "formatted": "world"},
+        ]
+    }
+    assert summarize(to_json_value(f)) == {"name": "world"}
+    f += "!"
+    assert summarize(to_json_value(f)) == {"f": {"name": "world"}}


### PR DESCRIPTION
Depends on #172 

Adds `argsSummary` and `resultSummary` to events in `trace.jsonl`. These contain shortened versions of `args` and `result` with large values truncated in terms of depth and length so that they can be loaded eagerly. They are meant to be viewed in a table and reduce the need to manually call `add_fields`. But since tables aren't merged in yet, currently this isn't used in the frontend.

I also think these should replace `shortArgs` and `shortResult` which are populated by `get_strings` which can sometimes produce weird results. However we would need to decide what actually gets shown in the nodes based on the summarized values. Should it show keys, or only values? Should it show anything nested? Should it show structure? How many values should it show?

Note that `get_strings` already works very poorly with serialised `F` objects, e.g. it may show only the constant parts. This can already be observed in #172. Here would be a good place to fix that.