### PR TITLE
Regression tests [ICE-42]

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+tests/expected_traces/

--- a/ice/trace.py
+++ b/ice/trace.py
@@ -200,9 +200,9 @@ class _Recorder:
         self.id = id
 
     def __call__(self, **kwargs):
-        emit(
-            {self.id: {"records": {trace_var.get().next_counter(): emit_block(kwargs)}}}
-        )
+        trc = trace_var.get()
+        assert trc is not None
+        emit({self.id: {"records": {trc.next_counter(): emit_block(kwargs)}}})
 
     def __repr__(self):
         # So this can be used in `diskcache()` functions
@@ -229,7 +229,9 @@ def trace(fn):
 
         @wraps(fn)
         async def inner_wrapper(*args, **kwargs):
-            id = trace_var.get().next_counter()
+            trc = trace_var.get()
+            assert trc is not None
+            id = trc.next_counter()
             parent_id = parent_id_var.get()
             parent_id_var.set(id)
 

--- a/ice/trace_reader.py
+++ b/ice/trace_reader.py
@@ -1,4 +1,5 @@
 import json
+
 from functools import lru_cache
 
 from ice.trace import traces_dir

--- a/ice/trace_reader.py
+++ b/ice/trace_reader.py
@@ -1,0 +1,44 @@
+import json
+from functools import lru_cache
+
+from ice.trace import traces_dir
+
+
+class TraceReader:
+    def __init__(self, trace_id: str):
+        self.trace_id = trace_id
+        self._block_lines_cached = lru_cache(self._block_lines)
+
+    @property
+    def dir(self):
+        return traces_dir / self.trace_id
+
+    @property
+    def trace_file(self):
+        return self.dir / "trace.jsonl"
+
+    def _block_lines(self, block_num):
+        block_file = self.dir / f"block_{block_num}.jsonl"
+        return block_file.read_text().splitlines()
+
+    def block_value(self, address):
+        num, lineno = address
+        return json.loads(self._block_lines_cached(num)[lineno])
+
+    def raw_events(self):
+        for line in self.trace_file.open():
+            yield json.loads(line)
+
+    def events_with_block_values(self):
+        for event in self.raw_events():
+            [[call_id, data]] = event.items()
+            assert call_id.isdigit()
+            if "start" in data:
+                data["args"] = self.block_value(data["args"])
+                data["func"] = self.block_value(data["func"])
+            elif "end" in data:
+                data["result"] = self.block_value(data["result"])
+            elif "records" in data:
+                [[record_id, record]] = data["records"].items()
+                data["records"][record_id] = self.block_value(record)
+            yield event

--- a/tests/expected_traces/AdherenceKeywordBaseline.json
+++ b/tests/expected_traces/AdherenceKeywordBaseline.json
@@ -4,7 +4,9 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": ["./papers/keenan-2018-tiny.txt"],
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -13,7 +15,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -30,19 +34,25 @@
       "cls": "AdherenceKeywordBaseline",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
     "2": {
       "result": [],
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/AdherenceKeywordBaseline.json
+++ b/tests/expected_traces/AdherenceKeywordBaseline.json
@@ -1,0 +1,58 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "AdherenceKeywordBaseline"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "self": {
+          "class_name": "AdherenceKeywordBaseline",
+          "mode": "test"
+        }
+      },
+      "cls": "AdherenceKeywordBaseline",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [],
+      "shortResult": [
+        "()"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/AdherenceKeywordBaseline.json
+++ b/tests/expected_traces/AdherenceKeywordBaseline.json
@@ -4,9 +4,7 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": [
-          "./papers/keenan-2018-tiny.txt"
-        ],
+        "input_files": ["./papers/keenan-2018-tiny.txt"],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -15,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -34,25 +30,19 @@
       "cls": "AdherenceKeywordBaseline",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
     "2": {
       "result": [],
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/AdherenceParagraphTfew.json
+++ b/tests/expected_traces/AdherenceParagraphTfew.json
@@ -1,0 +1,84 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "AdherenceParagraphTfew"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "self": {
+          "class_name": "AdherenceParagraphTfew",
+          "mode": "test"
+        }
+      },
+      "cls": "AdherenceParagraphTfew",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "document_id": "keenan-2018-tiny.txt",
+        "question_short_name": "adherence",
+        "self": {
+          "class_name": "AdherenceParagraphTfew",
+          "mode": "test"
+        }
+      },
+      "cls": "AdherenceParagraphTfew",
+      "name": "list_experiments",
+      "parent": 2,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [],
+      "shortResult": [
+        "()"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [],
+      "shortResult": [
+        "()"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/AdherenceParagraphTfew.json
+++ b/tests/expected_traces/AdherenceParagraphTfew.json
@@ -4,9 +4,7 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": [
-          "./papers/keenan-2018-tiny.txt"
-        ],
+        "input_files": ["./papers/keenan-2018-tiny.txt"],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -15,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -34,9 +30,7 @@
       "cls": "AdherenceParagraphTfew",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -52,33 +46,25 @@
       "cls": "AdherenceParagraphTfew",
       "name": "list_experiments",
       "parent": 2,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
     "3": {
       "result": [],
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   },
   {
     "2": {
       "result": [],
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/AdherenceParagraphTfew.json
+++ b/tests/expected_traces/AdherenceParagraphTfew.json
@@ -4,7 +4,9 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": ["./papers/keenan-2018-tiny.txt"],
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -13,7 +15,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -30,7 +34,9 @@
       "cls": "AdherenceParagraphTfew",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -46,25 +52,33 @@
       "cls": "AdherenceParagraphTfew",
       "name": "list_experiments",
       "parent": 2,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
     "3": {
       "result": [],
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   },
   {
     "2": {
       "result": [],
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/AdherenceSimpleInstruct.json
+++ b/tests/expected_traces/AdherenceSimpleInstruct.json
@@ -4,9 +4,7 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": [
-          "./papers/keenan-2018-tiny.txt"
-        ],
+        "input_files": ["./papers/keenan-2018-tiny.txt"],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -15,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -38,9 +34,7 @@
       "cls": "AdherenceSimpleInstruct",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -58,25 +52,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": [
-        "Human: I'm trying to evaluate som..."
-      ]
+      "shortArgs": ["Human: I'm trying to evaluate som..."]
     }
   },
   {
     "3": {
       "result": "Produce society necessary various reduce.",
-      "shortResult": [
-        "Produce society necessary various r..."
-      ]
+      "shortResult": ["Produce society necessary various r..."]
     }
   },
   {
     "2": {
       "result": "Produce society necessary various reduce.",
-      "shortResult": [
-        "Produce society necessary various r..."
-      ]
+      "shortResult": ["Produce society necessary various r..."]
     }
   },
   {
@@ -94,9 +82,7 @@
       "cls": "AdherenceSimpleInstruct",
       "name": "evaluation_report",
       "parent": 1,
-      "shortArgs": [
-        "()"
-      ]
+      "shortArgs": ["()"]
     }
   },
   {
@@ -107,10 +93,7 @@
             "answer": "Produce society necessary various reduce.",
             "answer_rating": null,
             "classification_eq": [],
-            "classifications": [
-              null,
-              null
-            ],
+            "classifications": [null, null],
             "document_id": "keenan-2018.pdf",
             "elicit_commit": null,
             "evaluated_excerpts": {
@@ -128,10 +111,7 @@
             "failure_modes": null,
             "gold_standard": {
               "answer": "Azithromycin was administered to 90% of participants.",
-              "classifications": [
-                "explicit",
-                null
-              ],
+              "classifications": ["explicit", null],
               "document_id": "keenan-2018.pdf",
               "experiment": "Oral azithromycin for childhood mortality",
               "question_short_name": "adherence",
@@ -146,17 +126,13 @@
         ],
         "technique_name": "AdherenceSimpleInstruct"
       },
-      "shortResult": [
-        "AdherenceSimpleInstruct"
-      ]
+      "shortResult": ["AdherenceSimpleInstruct"]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/AdherenceSimpleInstruct.json
+++ b/tests/expected_traces/AdherenceSimpleInstruct.json
@@ -1,0 +1,162 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "AdherenceSimpleInstruct"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "self": {
+          "agent_str": "instruct",
+          "class_name": "AdherenceSimpleInstruct",
+          "max_tokens": 3500,
+          "mode": "test",
+          "qa_prompt_template": "\n\nHuman: I'm trying to evaluate some RCTs. I've been told I should consider the adherence, attrition, and compliance of these papers when thinking about how much I should trust their results. Can you define these terms for me?\n\nAssistant: Sure, adherence describes how many participants selected for an intervention actually received it. Attrition describes how many of the initial sample dropped out of the study or were otherwise not available to be included in the final analysis. Compliance describes how well participants in the intervention complied with its protocol. All of these are important for the internal validity of a study, which informs how much we should trust its results.\n\nHuman: Here's the text of a paper I've been thinking about. Can you read it and summarize what it says, if anything, about adherence, attrition, and compliance?\n\n{paper_text}\n\nAssistant: First, I'll identify all the parts of the paper that talk about adherence, attrition, or compliance. Then, I'll summarize these sections.",
+          "question_short_name": "adherence"
+        }
+      },
+      "cls": "AdherenceSimpleInstruct",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "default": "",
+        "max_tokens": 300,
+        "prompt": "\n\nHuman: I'm trying to evaluate some RCTs. I've been told I should consider the adherence, attrition, and compliance of these papers when thinking about how much I should trust their results. Can you define these terms for me?\n\nAssistant: Sure, adherence describes how many participants selected for an intervention actually received it. Attrition describes how many of the initial sample dropped out of the study or were otherwise not available to be included in the final analysis. Compliance describes how well participants in the intervention complied with its protocol. All of these are important for the internal validity of a study, which informs how much we should trust its results.\n\nHuman: Here's the text of a paper I've been thinking about. Can you read it and summarize what it says, if anything, about adherence, attrition, and compliance?\n\nIn this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo. Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial. Vital status was determined at subsequent censuses. The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses. Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger. Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance. (Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)\n\nTrachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17\n\nMORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.\n\nLists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF). For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org). Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing). Only key trial personnel were aware of which letters corresponded to each group. Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments. Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments. The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin. Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial.\n\nEach child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.\n\nThe results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups. At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania). Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001). The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively).\n\nAssistant: First, I'll identify all the parts of the paper that talk about adherence, attrition, or compliance. Then, I'll summarize these sections.",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 2,
+      "shortArgs": [
+        "Human: I'm trying to evaluate som..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": "Produce society necessary various reduce.",
+      "shortResult": [
+        "Produce society necessary various r..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Produce society necessary various reduce.",
+      "shortResult": [
+        "Produce society necessary various r..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "self": {
+          "agent_str": "instruct",
+          "class_name": "AdherenceSimpleInstruct",
+          "max_tokens": 3500,
+          "mode": "test",
+          "qa_prompt_template": "\n\nHuman: I'm trying to evaluate some RCTs. I've been told I should consider the adherence, attrition, and compliance of these papers when thinking about how much I should trust their results. Can you define these terms for me?\n\nAssistant: Sure, adherence describes how many participants selected for an intervention actually received it. Attrition describes how many of the initial sample dropped out of the study or were otherwise not available to be included in the final analysis. Compliance describes how well participants in the intervention complied with its protocol. All of these are important for the internal validity of a study, which informs how much we should trust its results.\n\nHuman: Here's the text of a paper I've been thinking about. Can you read it and summarize what it says, if anything, about adherence, attrition, and compliance?\n\n{paper_text}\n\nAssistant: First, I'll identify all the parts of the paper that talk about adherence, attrition, or compliance. Then, I'll summarize these sections.",
+          "question_short_name": "adherence"
+        }
+      },
+      "cls": "AdherenceSimpleInstruct",
+      "name": "evaluation_report",
+      "parent": 1,
+      "shortArgs": [
+        "()"
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": {
+        "results": [
+          {
+            "answer": "Produce society necessary various reduce.",
+            "answer_rating": null,
+            "classification_eq": [],
+            "classifications": [
+              null,
+              null
+            ],
+            "document_id": "keenan-2018.pdf",
+            "elicit_commit": null,
+            "evaluated_excerpts": {
+              "average_recall": 0.0,
+              "excerpts": [],
+              "gold_standards_in_excerpts_results": [
+                {
+                  "found": false,
+                  "text": "Azithromycin was administered to a mean (\u00b1SD) of 90.3\u00b110.6% of the targeted population, and placebo was administered to 90.4\u00b110.1% (see the Supplementary Appendix)."
+                }
+              ]
+            },
+            "excerpts": [],
+            "experiment": "Oral azithromycin for childhood mortality",
+            "failure_modes": null,
+            "gold_standard": {
+              "answer": "Azithromycin was administered to 90% of participants.",
+              "classifications": [
+                "explicit",
+                null
+              ],
+              "document_id": "keenan-2018.pdf",
+              "experiment": "Oral azithromycin for childhood mortality",
+              "question_short_name": "adherence",
+              "quotes": [
+                "Azithromycin was administered to a mean (\u00b1SD) of 90.3\u00b110.6% of the targeted population, and placebo was administered to 90.4\u00b110.1% (see the Supplementary Appendix)."
+              ],
+              "split": "iterate"
+            },
+            "question_short_name": "adherence",
+            "result": "Produce society necessary various reduce."
+          }
+        ],
+        "technique_name": "AdherenceSimpleInstruct"
+      },
+      "shortResult": [
+        "AdherenceSimpleInstruct"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/AdherenceSimpleInstruct.json
+++ b/tests/expected_traces/AdherenceSimpleInstruct.json
@@ -4,7 +4,9 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": ["./papers/keenan-2018-tiny.txt"],
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -13,7 +15,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -34,7 +38,9 @@
       "cls": "AdherenceSimpleInstruct",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -52,19 +58,25 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": ["Human: I'm trying to evaluate som..."]
+      "shortArgs": [
+        "Human: I'm trying to evaluate som..."
+      ]
     }
   },
   {
     "3": {
       "result": "Produce society necessary various reduce.",
-      "shortResult": ["Produce society necessary various r..."]
+      "shortResult": [
+        "Produce society necessary various r..."
+      ]
     }
   },
   {
     "2": {
       "result": "Produce society necessary various reduce.",
-      "shortResult": ["Produce society necessary various r..."]
+      "shortResult": [
+        "Produce society necessary various r..."
+      ]
     }
   },
   {
@@ -82,7 +94,9 @@
       "cls": "AdherenceSimpleInstruct",
       "name": "evaluation_report",
       "parent": 1,
-      "shortArgs": ["()"]
+      "shortArgs": [
+        "()"
+      ]
     }
   },
   {
@@ -93,7 +107,10 @@
             "answer": "Produce society necessary various reduce.",
             "answer_rating": null,
             "classification_eq": [],
-            "classifications": [null, null],
+            "classifications": [
+              null,
+              null
+            ],
             "document_id": "keenan-2018.pdf",
             "elicit_commit": null,
             "evaluated_excerpts": {
@@ -111,7 +128,10 @@
             "failure_modes": null,
             "gold_standard": {
               "answer": "Azithromycin was administered to 90% of participants.",
-              "classifications": ["explicit", null],
+              "classifications": [
+                "explicit",
+                null
+              ],
               "document_id": "keenan-2018.pdf",
               "experiment": "Oral azithromycin for childhood mortality",
               "question_short_name": "adherence",
@@ -126,13 +146,17 @@
         ],
         "technique_name": "AdherenceSimpleInstruct"
       },
-      "shortResult": ["AdherenceSimpleInstruct"]
+      "shortResult": [
+        "AdherenceSimpleInstruct"
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/AllQuotesRecipe.json
+++ b/tests/expected_traces/AllQuotesRecipe.json
@@ -4,9 +4,7 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": [
-          "./papers/keenan-2018-tiny.txt"
-        ],
+        "input_files": ["./papers/keenan-2018-tiny.txt"],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -15,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -35,25 +31,19 @@
       "cls": "AllQuotesRecipe",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
     "2": {
       "result": [],
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/AllQuotesRecipe.json
+++ b/tests/expected_traces/AllQuotesRecipe.json
@@ -1,0 +1,59 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "AllQuotesRecipe"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "self": {
+          "class_name": "AllQuotesRecipe",
+          "mode": "test",
+          "question_short_name_to_test": "placebo"
+        }
+      },
+      "cls": "AllQuotesRecipe",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [],
+      "shortResult": [
+        "()"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/AllQuotesRecipe.json
+++ b/tests/expected_traces/AllQuotesRecipe.json
@@ -4,7 +4,9 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": ["./papers/keenan-2018-tiny.txt"],
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -13,7 +15,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -31,19 +35,25 @@
       "cls": "AllQuotesRecipe",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
     "2": {
       "result": [],
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/BlindingDynamic.json
+++ b/tests/expected_traces/BlindingDynamic.json
@@ -4,9 +4,7 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": [
-          "./papers/keenan-2018-tiny.txt"
-        ],
+        "input_files": ["./papers/keenan-2018-tiny.txt"],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -15,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -34,9 +30,7 @@
       "cls": "BlindingDynamic",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -53,33 +47,25 @@
       "cls": "BlindingDynamic",
       "name": "interventions",
       "parent": 2,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
     "3": {
       "result": [],
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   },
   {
     "2": {
       "result": [],
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/BlindingDynamic.json
+++ b/tests/expected_traces/BlindingDynamic.json
@@ -4,7 +4,9 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": ["./papers/keenan-2018-tiny.txt"],
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -13,7 +15,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -30,7 +34,9 @@
       "cls": "BlindingDynamic",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -47,25 +53,33 @@
       "cls": "BlindingDynamic",
       "name": "interventions",
       "parent": 2,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
     "3": {
       "result": [],
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   },
   {
     "2": {
       "result": [],
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/BlindingDynamic.json
+++ b/tests/expected_traces/BlindingDynamic.json
@@ -1,0 +1,85 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "BlindingDynamic"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "self": {
+          "class_name": "BlindingDynamic",
+          "mode": "test"
+        }
+      },
+      "cls": "BlindingDynamic",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "self": {
+          "class_name": "BlindingDynamic",
+          "mode": "test"
+        }
+      },
+      "cls": "BlindingDynamic",
+      "name": "interventions",
+      "parent": 2,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [],
+      "shortResult": [
+        "()"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [],
+      "shortResult": [
+        "()"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/ComparisonsQA.json
+++ b/tests/expected_traces/ComparisonsQA.json
@@ -4,7 +4,9 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": ["./papers/keenan-2018-tiny.txt"],
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -13,7 +15,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -34,7 +38,9 @@
       "cls": "ComparisonsQA",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -53,7 +59,9 @@
       "cls": "RankParagraphs",
       "name": "run",
       "parent": 2,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -65,19 +73,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "4": {
       "result": "Realize environment street manage whom.",
-      "shortResult": ["Realize environment street manage w..."]
+      "shortResult": [
+        "Realize environment street manage w..."
+      ]
     }
   },
   {
@@ -89,19 +104,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "5": {
       "result": "Campaign common know save help nation option.",
-      "shortResult": ["Campaign common know save help nati..."]
+      "shortResult": [
+        "Campaign common know save help nati..."
+      ]
     }
   },
   {
@@ -113,19 +135,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "6": {
       "result": "Career care deep lawyer hour onto production.",
-      "shortResult": ["Career care deep lawyer hour onto p..."]
+      "shortResult": [
+        "Career care deep lawyer hour onto p..."
+      ]
     }
   },
   {
@@ -137,19 +166,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "7": {
       "result": "Television follow owner send ahead season.",
-      "shortResult": ["Television follow owner send ahead..."]
+      "shortResult": [
+        "Television follow owner send ahead..."
+      ]
     }
   },
   {
@@ -161,19 +197,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "8": {
       "result": "Every region especially some drug learn detail.",
-      "shortResult": ["Every region especially some drug l..."]
+      "shortResult": [
+        "Every region especially some drug l..."
+      ]
     }
   },
   {
@@ -185,19 +228,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "9": {
       "result": "Customer majority area image eight computer hospital know.",
-      "shortResult": ["Customer majority area image eight..."]
+      "shortResult": [
+        "Customer majority area image eight..."
+      ]
     }
   },
   {
@@ -209,19 +259,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "10": {
       "result": "Only ready treat school treat.",
-      "shortResult": ["Only ready treat school treat."]
+      "shortResult": [
+        "Only ready treat school treat."
+      ]
     }
   },
   {
@@ -233,19 +290,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "11": {
       "result": "Form read specific remember little third discover.",
-      "shortResult": ["Form read specific remember little..."]
+      "shortResult": [
+        "Form read specific remember little..."
+      ]
     }
   },
   {
@@ -257,19 +321,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "12": {
       "result": "Executive role lot she attack candidate simple.",
-      "shortResult": ["Executive role lot she attack candi..."]
+      "shortResult": [
+        "Executive role lot she attack candi..."
+      ]
     }
   },
   {
@@ -281,19 +352,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "13": {
       "result": "Do operation fine color forward.",
-      "shortResult": ["Do operation fine color forward."]
+      "shortResult": [
+        "Do operation fine color forward."
+      ]
     }
   },
   {
@@ -305,19 +383,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "14": {
       "result": "Father fall much continue responsibility.",
-      "shortResult": ["Father fall much continue responsib..."]
+      "shortResult": [
+        "Father fall much continue responsib..."
+      ]
     }
   },
   {
@@ -329,19 +414,26 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [" ", "\n"],
+        "stop": [
+          " ",
+          "\n"
+        ],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Which of paragraphs A and B better..."]
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
     }
   },
   {
     "15": {
       "result": "Magazine million can customer.",
-      "shortResult": ["Magazine million can customer."]
+      "shortResult": [
+        "Magazine million can customer."
+      ]
     }
   },
   {
@@ -395,7 +487,9 @@
           ]
         }
       ],
-      "shortResult": ["Trachoma-control programs have dist..."]
+      "shortResult": [
+        "Trachoma-control programs have dist..."
+      ]
     }
   },
   {
@@ -413,25 +507,33 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": ["Answer the question \"What were the..."]
+      "shortArgs": [
+        "Answer the question \"What were the..."
+      ]
     }
   },
   {
     "16": {
       "result": "Write special apply eight statement spend.",
-      "shortResult": ["Write special apply eight statement..."]
+      "shortResult": [
+        "Write special apply eight statement..."
+      ]
     }
   },
   {
     "2": {
       "result": "Write special apply eight statement spend.",
-      "shortResult": ["Write special apply eight statement..."]
+      "shortResult": [
+        "Write special apply eight statement..."
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/ComparisonsQA.json
+++ b/tests/expected_traces/ComparisonsQA.json
@@ -4,9 +4,7 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": [
-          "./papers/keenan-2018-tiny.txt"
-        ],
+        "input_files": ["./papers/keenan-2018-tiny.txt"],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -15,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -38,9 +34,7 @@
       "cls": "ComparisonsQA",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -59,9 +53,7 @@
       "cls": "RankParagraphs",
       "name": "run",
       "parent": 2,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -73,26 +65,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "4": {
       "result": "Realize environment street manage whom.",
-      "shortResult": [
-        "Realize environment street manage w..."
-      ]
+      "shortResult": ["Realize environment street manage w..."]
     }
   },
   {
@@ -104,26 +89,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "5": {
       "result": "Campaign common know save help nation option.",
-      "shortResult": [
-        "Campaign common know save help nati..."
-      ]
+      "shortResult": ["Campaign common know save help nati..."]
     }
   },
   {
@@ -135,26 +113,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "6": {
       "result": "Career care deep lawyer hour onto production.",
-      "shortResult": [
-        "Career care deep lawyer hour onto p..."
-      ]
+      "shortResult": ["Career care deep lawyer hour onto p..."]
     }
   },
   {
@@ -166,26 +137,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "7": {
       "result": "Television follow owner send ahead season.",
-      "shortResult": [
-        "Television follow owner send ahead..."
-      ]
+      "shortResult": ["Television follow owner send ahead..."]
     }
   },
   {
@@ -197,26 +161,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "8": {
       "result": "Every region especially some drug learn detail.",
-      "shortResult": [
-        "Every region especially some drug l..."
-      ]
+      "shortResult": ["Every region especially some drug l..."]
     }
   },
   {
@@ -228,26 +185,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "9": {
       "result": "Customer majority area image eight computer hospital know.",
-      "shortResult": [
-        "Customer majority area image eight..."
-      ]
+      "shortResult": ["Customer majority area image eight..."]
     }
   },
   {
@@ -259,26 +209,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "10": {
       "result": "Only ready treat school treat.",
-      "shortResult": [
-        "Only ready treat school treat."
-      ]
+      "shortResult": ["Only ready treat school treat."]
     }
   },
   {
@@ -290,26 +233,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "11": {
       "result": "Form read specific remember little third discover.",
-      "shortResult": [
-        "Form read specific remember little..."
-      ]
+      "shortResult": ["Form read specific remember little..."]
     }
   },
   {
@@ -321,26 +257,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "12": {
       "result": "Executive role lot she attack candidate simple.",
-      "shortResult": [
-        "Executive role lot she attack candi..."
-      ]
+      "shortResult": ["Executive role lot she attack candi..."]
     }
   },
   {
@@ -352,26 +281,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "13": {
       "result": "Do operation fine color forward.",
-      "shortResult": [
-        "Do operation fine color forward."
-      ]
+      "shortResult": ["Do operation fine color forward."]
     }
   },
   {
@@ -383,26 +305,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "14": {
       "result": "Father fall much continue responsibility.",
-      "shortResult": [
-        "Father fall much continue responsib..."
-      ]
+      "shortResult": ["Father fall much continue responsib..."]
     }
   },
   {
@@ -414,26 +329,19 @@
         "self": {
           "class_name": "FakeAgent"
         },
-        "stop": [
-          " ",
-          "\n"
-        ],
+        "stop": [" ", "\n"],
         "verbose": false
       },
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Which of paragraphs A and B better..."
-      ]
+      "shortArgs": ["Which of paragraphs A and B better..."]
     }
   },
   {
     "15": {
       "result": "Magazine million can customer.",
-      "shortResult": [
-        "Magazine million can customer."
-      ]
+      "shortResult": ["Magazine million can customer."]
     }
   },
   {
@@ -487,9 +395,7 @@
           ]
         }
       ],
-      "shortResult": [
-        "Trachoma-control programs have dist..."
-      ]
+      "shortResult": ["Trachoma-control programs have dist..."]
     }
   },
   {
@@ -507,33 +413,25 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": [
-        "Answer the question \"What were the..."
-      ]
+      "shortArgs": ["Answer the question \"What were the..."]
     }
   },
   {
     "16": {
       "result": "Write special apply eight statement spend.",
-      "shortResult": [
-        "Write special apply eight statement..."
-      ]
+      "shortResult": ["Write special apply eight statement..."]
     }
   },
   {
     "2": {
       "result": "Write special apply eight statement spend.",
-      "shortResult": [
-        "Write special apply eight statement..."
-      ]
+      "shortResult": ["Write special apply eight statement..."]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/ComparisonsQA.json
+++ b/tests/expected_traces/ComparisonsQA.json
@@ -1,0 +1,539 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "ComparisonsQA"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "answer_prefix": "Answer: The trial arms were:\n-",
+        "num_paragraphs": 3,
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "question_long": "What were the trial arms (subgroups of participants) of the experiment? List one per line.",
+        "question_short": "What were the trial arms (subgroups of participants) of the experiment?",
+        "self": {
+          "class_name": "ComparisonsQA",
+          "mode": "test"
+        }
+      },
+      "cls": "ComparisonsQA",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "n": 3,
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "question": "What were the trial arms (subgroups of participants) of the experiment?",
+        "self": {
+          "class_name": "RankParagraphs",
+          "mode": "test"
+        }
+      },
+      "cls": "RankParagraphs",
+      "name": "run",
+      "parent": 2,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo. Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial. Vital status was determined at subsequent censuses. The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses. Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger. Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance. (Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)\n\nParagraph B: Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": "Realize environment street manage whom.",
+      "shortResult": [
+        "Realize environment street manage w..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.\n\nParagraph B: Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": "Campaign common know save help nation option.",
+      "shortResult": [
+        "Campaign common know save help nati..."
+      ]
+    }
+  },
+  {
+    "6": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: Lists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF). For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org). Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing). Only key trial personnel were aware of which letters corresponded to each group. Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments. Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments. The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin. Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial.\n\nParagraph B: Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "6": {
+      "result": "Career care deep lawyer hour onto production.",
+      "shortResult": [
+        "Career care deep lawyer hour onto p..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.\n\nParagraph B: Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "result": "Television follow owner send ahead season.",
+      "shortResult": [
+        "Television follow owner send ahead..."
+      ]
+    }
+  },
+  {
+    "8": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: The results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups. At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania). Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001). The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively).\n\nParagraph B: Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "8": {
+      "result": "Every region especially some drug learn detail.",
+      "shortResult": [
+        "Every region especially some drug l..."
+      ]
+    }
+  },
+  {
+    "9": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo. Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial. Vital status was determined at subsequent censuses. The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses. Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger. Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance. (Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)\n\nParagraph B: MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "9": {
+      "result": "Customer majority area image eight computer hospital know.",
+      "shortResult": [
+        "Customer majority area image eight..."
+      ]
+    }
+  },
+  {
+    "10": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: Lists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF). For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org). Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing). Only key trial personnel were aware of which letters corresponded to each group. Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments. Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments. The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin. Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial.\n\nParagraph B: MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "10": {
+      "result": "Only ready treat school treat.",
+      "shortResult": [
+        "Only ready treat school treat."
+      ]
+    }
+  },
+  {
+    "11": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.\n\nParagraph B: MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "11": {
+      "result": "Form read specific remember little third discover.",
+      "shortResult": [
+        "Form read specific remember little..."
+      ]
+    }
+  },
+  {
+    "12": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: The results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups. At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania). Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001). The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively).\n\nParagraph B: MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "12": {
+      "result": "Executive role lot she attack candidate simple.",
+      "shortResult": [
+        "Executive role lot she attack candi..."
+      ]
+    }
+  },
+  {
+    "13": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo. Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial. Vital status was determined at subsequent censuses. The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses. Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger. Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance. (Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)\n\nParagraph B: Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "13": {
+      "result": "Do operation fine color forward.",
+      "shortResult": [
+        "Do operation fine color forward."
+      ]
+    }
+  },
+  {
+    "14": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: Lists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF). For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org). Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing). Only key trial personnel were aware of which letters corresponded to each group. Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments. Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments. The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin. Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial.\n\nParagraph B: Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "14": {
+      "result": "Father fall much continue responsibility.",
+      "shortResult": [
+        "Father fall much continue responsib..."
+      ]
+    }
+  },
+  {
+    "15": {
+      "args": {
+        "default": "",
+        "max_tokens": 1,
+        "prompt": "Which of paragraphs A and B better answers the question \"What were the trial arms (subgroups of participants) of the experiment?\"?\n\nParagraph A: The results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups. At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania). Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001). The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively).\n\nParagraph B: Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.\n\nQuestion: Which of paragraphs A and B better answers the question 'What were the trial arms (subgroups of participants) of the experiment?'? Answer with \"Paragraph A\" or \"Paragraph B\".\n\nAnswer: Paragraph",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": [
+          " ",
+          "\n"
+        ],
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Which of paragraphs A and B better..."
+      ]
+    }
+  },
+  {
+    "15": {
+      "result": "Magazine million can customer.",
+      "shortResult": [
+        "Magazine million can customer."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [
+        {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "1",
+              "title": "Introduction"
+            }
+          ],
+          "sentences": [
+            "Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17"
+          ]
+        },
+        {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "2",
+              "title": "Eligibility"
+            }
+          ],
+          "sentences": [
+            "MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization.",
+            "The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania.",
+            "None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin.",
+            "Enrollment was based on census information available before the trial.",
+            "Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org).",
+            "Communities remained in the trial even if the population drifted out of this range.",
+            "All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo."
+          ]
+        },
+        {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "4",
+              "title": "Intervention"
+            }
+          ],
+          "sentences": [
+            "Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community).",
+            "Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand.",
+            "Children who were known to be allergic to macrolides were not given azithromycin or placebo.",
+            "Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage.",
+            "Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census.",
+            "The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF."
+          ]
+        }
+      ],
+      "shortResult": [
+        "Trachoma-control programs have dist..."
+      ]
+    }
+  },
+  {
+    "16": {
+      "args": {
+        "default": "",
+        "max_tokens": 500,
+        "prompt": "Answer the question \"What were the trial arms (subgroups of participants) of the experiment?\" based on the following paragraphs.\n\nParagraphs:\n\nTrachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17\n\nMORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.\n\nEach child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.\n\nQuestion: What were the trial arms (subgroups of participants) of the experiment? List one per line.\n\nAnswer: The trial arms were:\n-",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 2,
+      "shortArgs": [
+        "Answer the question \"What were the..."
+      ]
+    }
+  },
+  {
+    "16": {
+      "result": "Write special apply eight statement spend.",
+      "shortResult": [
+        "Write special apply eight statement..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Write special apply eight statement spend.",
+      "shortResult": [
+        "Write special apply eight statement..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/EvaluateResult.json
+++ b/tests/expected_traces/EvaluateResult.json
@@ -13,7 +13,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -30,7 +32,9 @@
       "cls": "EvaluateResult",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["()"]
+      "shortArgs": [
+        "()"
+      ]
     }
   },
   {
@@ -48,19 +52,26 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": ["Compare the following results from..."]
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
     }
   },
   {
     "3": {
       "result": "Major behavior mention high beat.",
-      "shortResult": ["Major behavior mention high beat."]
+      "shortResult": [
+        "Major behavior mention high beat."
+      ]
     }
   },
   {
     "4": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Major behavior mention high beat.\n\nDoes model result E capture all important information from gold standard E?",
         "self": {
@@ -71,7 +82,9 @@
       "cls": "FakeAgent",
       "name": "classify",
       "parent": 2,
-      "shortArgs": ["Compare the following results from..."]
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
     }
   },
   {
@@ -83,7 +96,9 @@
         },
         null
       ],
-      "shortResult": ["0.988207128381771"]
+      "shortResult": [
+        "0.988207128381771"
+      ]
     }
   },
   {
@@ -93,13 +108,17 @@
         "missing_info": "Major behavior mention high beat.",
         "p_complete": 0.988207128381771
       },
-      "shortResult": ["Major behavior mention high beat."]
+      "shortResult": [
+        "Major behavior mention high beat."
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/EvaluateResult.json
+++ b/tests/expected_traces/EvaluateResult.json
@@ -13,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -32,9 +30,7 @@
       "cls": "EvaluateResult",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "()"
-      ]
+      "shortArgs": ["()"]
     }
   },
   {
@@ -52,26 +48,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": [
-        "Compare the following results from..."
-      ]
+      "shortArgs": ["Compare the following results from..."]
     }
   },
   {
     "3": {
       "result": "Major behavior mention high beat.",
-      "shortResult": [
-        "Major behavior mention high beat."
-      ]
+      "shortResult": ["Major behavior mention high beat."]
     }
   },
   {
     "4": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Major behavior mention high beat.\n\nDoes model result E capture all important information from gold standard E?",
         "self": {
@@ -82,9 +71,7 @@
       "cls": "FakeAgent",
       "name": "classify",
       "parent": 2,
-      "shortArgs": [
-        "Compare the following results from..."
-      ]
+      "shortArgs": ["Compare the following results from..."]
     }
   },
   {
@@ -96,9 +83,7 @@
         },
         null
       ],
-      "shortResult": [
-        "0.988207128381771"
-      ]
+      "shortResult": ["0.988207128381771"]
     }
   },
   {
@@ -108,17 +93,13 @@
         "missing_info": "Major behavior mention high beat.",
         "p_complete": 0.988207128381771
       },
-      "shortResult": [
-        "Major behavior mention high beat."
-      ]
+      "shortResult": ["Major behavior mention high beat."]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/EvaluateResult.json
+++ b/tests/expected_traces/EvaluateResult.json
@@ -1,0 +1,124 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": null,
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "EvaluateResult"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "gold_result": null,
+        "model_result": null,
+        "question": null,
+        "self": {
+          "class_name": "EvaluateResult",
+          "mode": "test"
+        }
+      },
+      "cls": "EvaluateResult",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "()"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "default": "",
+        "max_tokens": 200,
+        "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E?",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 2,
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": "Major behavior mention high beat.",
+      "shortResult": [
+        "Major behavior mention high beat."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Major behavior mention high beat.\n\nDoes model result E capture all important information from gold standard E?",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 2,
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": [
+        {
+          " No": 0.011792871618228935,
+          " Yes": 0.988207128381771
+        },
+        null
+      ],
+      "shortResult": [
+        "0.988207128381771"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": {
+        "is_complete": true,
+        "missing_info": "Major behavior mention high beat.",
+        "p_complete": 0.988207128381771
+      },
+      "shortResult": [
+        "Major behavior mention high beat."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/EvaluateResults.json
+++ b/tests/expected_traces/EvaluateResults.json
@@ -13,7 +13,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -30,7 +32,9 @@
       "cls": "EvaluateResults",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["()"]
+      "shortArgs": [
+        "()"
+      ]
     }
   },
   {
@@ -47,7 +51,9 @@
       "cls": "EvaluateResult",
       "name": "run",
       "parent": 2,
-      "shortArgs": ["Placebo gelatin capsules made of st..."]
+      "shortArgs": [
+        "Placebo gelatin capsules made of st..."
+      ]
     }
   },
   {
@@ -65,19 +71,26 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Compare the following results from..."]
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
     }
   },
   {
     "4": {
       "result": "Economy understand part hair trade model.",
-      "shortResult": ["Economy understand part hair trade..."]
+      "shortResult": [
+        "Economy understand part hair trade..."
+      ]
     }
   },
   {
     "5": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Economy understand part hair trade model.\n\nDoes model result E capture all important information from gold standard E?",
         "self": {
@@ -88,7 +101,9 @@
       "cls": "FakeAgent",
       "name": "classify",
       "parent": 3,
-      "shortArgs": ["Compare the following results from..."]
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
     }
   },
   {
@@ -100,7 +115,9 @@
         },
         null
       ],
-      "shortResult": ["0.6324400348948942"]
+      "shortResult": [
+        "0.6324400348948942"
+      ]
     }
   },
   {
@@ -110,7 +127,9 @@
         "missing_info": "Economy understand part hair trade model.",
         "p_complete": 0.6324400348948942
       },
-      "shortResult": ["Economy understand part hair trade..."]
+      "shortResult": [
+        "Economy understand part hair trade..."
+      ]
     }
   },
   {
@@ -127,7 +146,9 @@
       "cls": "EvaluateResult",
       "name": "run",
       "parent": 2,
-      "shortArgs": ["The placebo consisted of chloroquin..."]
+      "shortArgs": [
+        "The placebo consisted of chloroquin..."
+      ]
     }
   },
   {
@@ -145,19 +166,26 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 6,
-      "shortArgs": ["Compare the following results from..."]
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
     }
   },
   {
     "7": {
       "result": "Card deal front key wonder career.",
-      "shortResult": ["Card deal front key wonder career."]
+      "shortResult": [
+        "Card deal front key wonder career."
+      ]
     }
   },
   {
     "8": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Card deal front key wonder career.\n\nDoes model result E capture all important information from gold standard E?",
         "self": {
@@ -168,7 +196,9 @@
       "cls": "FakeAgent",
       "name": "classify",
       "parent": 6,
-      "shortArgs": ["Compare the following results from..."]
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
     }
   },
   {
@@ -180,7 +210,9 @@
         },
         null
       ],
-      "shortResult": ["0.6254567461490756"]
+      "shortResult": [
+        "0.6254567461490756"
+      ]
     }
   },
   {
@@ -190,7 +222,9 @@
         "missing_info": "Card deal front key wonder career.",
         "p_complete": 0.6254567461490756
       },
-      "shortResult": ["Card deal front key wonder career."]
+      "shortResult": [
+        "Card deal front key wonder career."
+      ]
     }
   },
   {
@@ -207,7 +241,9 @@
       "cls": "EvaluateResult",
       "name": "run",
       "parent": 2,
-      "shortArgs": ["The placebo was a fake treatment th..."]
+      "shortArgs": [
+        "The placebo was a fake treatment th..."
+      ]
     }
   },
   {
@@ -225,19 +261,26 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 9,
-      "shortArgs": ["Compare the following results from..."]
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
     }
   },
   {
     "10": {
       "result": "Company show in someone require price decade most.",
-      "shortResult": ["Company show in someone require pri..."]
+      "shortResult": [
+        "Company show in someone require pri..."
+      ]
     }
   },
   {
     "11": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Company show in someone require price decade most.\n\nDoes model result E capture all important information from gold standard E?",
         "self": {
@@ -248,7 +291,9 @@
       "cls": "FakeAgent",
       "name": "classify",
       "parent": 9,
-      "shortArgs": ["Compare the following results from..."]
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
     }
   },
   {
@@ -260,7 +305,9 @@
         },
         null
       ],
-      "shortResult": ["0.9085700657138878"]
+      "shortResult": [
+        "0.9085700657138878"
+      ]
     }
   },
   {
@@ -270,7 +317,9 @@
         "missing_info": "Company show in someone require price decade most.",
         "p_complete": 0.9085700657138878
       },
-      "shortResult": ["Company show in someone require pri..."]
+      "shortResult": [
+        "Company show in someone require pri..."
+      ]
     }
   },
   {
@@ -292,13 +341,17 @@
           "p_complete": 0.9085700657138878
         }
       ],
-      "shortResult": ["Economy understand part hair trade..."]
+      "shortResult": [
+        "Economy understand part hair trade..."
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/EvaluateResults.json
+++ b/tests/expected_traces/EvaluateResults.json
@@ -1,0 +1,357 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": null,
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "EvaluateResults"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "gold_results": null,
+        "model_results": null,
+        "question": null,
+        "self": {
+          "class_name": "EvaluateResults",
+          "mode": "test"
+        }
+      },
+      "cls": "EvaluateResults",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "()"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "gold_result": "The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.",
+        "model_result": "Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight",
+        "question": "What was the placebo in the study?",
+        "self": {
+          "class_name": "EvaluateResult",
+          "mode": "test"
+        }
+      },
+      "cls": "EvaluateResult",
+      "name": "run",
+      "parent": 2,
+      "shortArgs": [
+        "Placebo gelatin capsules made of st..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "default": "",
+        "max_tokens": 200,
+        "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E?",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": "Economy understand part hair trade model.",
+      "shortResult": [
+        "Economy understand part hair trade..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Economy understand part hair trade model.\n\nDoes model result E capture all important information from gold standard E?",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 3,
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": [
+        {
+          " No": 0.3675599651051059,
+          " Yes": 0.6324400348948942
+        },
+        null
+      ],
+      "shortResult": [
+        "0.6324400348948942"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": {
+        "is_complete": true,
+        "missing_info": "Economy understand part hair trade model.",
+        "p_complete": 0.6324400348948942
+      },
+      "shortResult": [
+        "Economy understand part hair trade..."
+      ]
+    }
+  },
+  {
+    "6": {
+      "args": {
+        "gold_result": "The placebo was chloroquine, proguanil, iron and folic acid tablets that had no active substances in them. It was identical in appearance and taste to the active tablets and were produced by the same company.",
+        "model_result": "The placebo consisted of chloroquine, proguanil, iron and folic acid tablets that had no active substances in them. They were identical in appearance and taste to the active tablets and were produced by the same company.",
+        "question": "What was the placebo in the study?",
+        "self": {
+          "class_name": "EvaluateResult",
+          "mode": "test"
+        }
+      },
+      "cls": "EvaluateResult",
+      "name": "run",
+      "parent": 2,
+      "shortArgs": [
+        "The placebo consisted of chloroquin..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "args": {
+        "default": "",
+        "max_tokens": 200,
+        "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E?",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 6,
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "result": "Card deal front key wonder career.",
+      "shortResult": [
+        "Card deal front key wonder career."
+      ]
+    }
+  },
+  {
+    "8": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Card deal front key wonder career.\n\nDoes model result E capture all important information from gold standard E?",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 6,
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
+    }
+  },
+  {
+    "8": {
+      "result": [
+        {
+          " No": 0.3745432538509244,
+          " Yes": 0.6254567461490756
+        },
+        null
+      ],
+      "shortResult": [
+        "0.6254567461490756"
+      ]
+    }
+  },
+  {
+    "6": {
+      "result": {
+        "is_complete": true,
+        "missing_info": "Card deal front key wonder career.",
+        "p_complete": 0.6254567461490756
+      },
+      "shortResult": [
+        "Card deal front key wonder career."
+      ]
+    }
+  },
+  {
+    "9": {
+      "args": {
+        "gold_result": "Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight",
+        "model_result": "The placebo was a fake treatment that looked like the real one but did not have any effect. It was made of chloroquine, proguanil, iron and folic acid tablets that had no active ingredients. The same company that made the real tablets also made the placebo tablets.",
+        "question": "What was the placebo in the study?",
+        "self": {
+          "class_name": "EvaluateResult",
+          "mode": "test"
+        }
+      },
+      "cls": "EvaluateResult",
+      "name": "run",
+      "parent": 2,
+      "shortArgs": [
+        "The placebo was a fake treatment th..."
+      ]
+    }
+  },
+  {
+    "10": {
+      "args": {
+        "default": "",
+        "max_tokens": 200,
+        "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E?",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 9,
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
+    }
+  },
+  {
+    "10": {
+      "result": "Company show in someone require price decade most.",
+      "shortResult": [
+        "Company show in someone require pri..."
+      ]
+    }
+  },
+  {
+    "11": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Company show in someone require price decade most.\n\nDoes model result E capture all important information from gold standard E?",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 9,
+      "shortArgs": [
+        "Compare the following results from..."
+      ]
+    }
+  },
+  {
+    "11": {
+      "result": [
+        {
+          " No": 0.09142993428611218,
+          " Yes": 0.9085700657138878
+        },
+        null
+      ],
+      "shortResult": [
+        "0.9085700657138878"
+      ]
+    }
+  },
+  {
+    "9": {
+      "result": {
+        "is_complete": true,
+        "missing_info": "Company show in someone require price decade most.",
+        "p_complete": 0.9085700657138878
+      },
+      "shortResult": [
+        "Company show in someone require pri..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [
+        {
+          "is_complete": true,
+          "missing_info": "Economy understand part hair trade model.",
+          "p_complete": 0.6324400348948942
+        },
+        {
+          "is_complete": true,
+          "missing_info": "Card deal front key wonder career.",
+          "p_complete": 0.6254567461490756
+        },
+        {
+          "is_complete": true,
+          "missing_info": "Company show in someone require price decade most.",
+          "p_complete": 0.9085700657138878
+        }
+      ],
+      "shortResult": [
+        "Economy understand part hair trade..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/EvaluateResults.json
+++ b/tests/expected_traces/EvaluateResults.json
@@ -13,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -32,9 +30,7 @@
       "cls": "EvaluateResults",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "()"
-      ]
+      "shortArgs": ["()"]
     }
   },
   {
@@ -51,9 +47,7 @@
       "cls": "EvaluateResult",
       "name": "run",
       "parent": 2,
-      "shortArgs": [
-        "Placebo gelatin capsules made of st..."
-      ]
+      "shortArgs": ["Placebo gelatin capsules made of st..."]
     }
   },
   {
@@ -71,26 +65,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Compare the following results from..."
-      ]
+      "shortArgs": ["Compare the following results from..."]
     }
   },
   {
     "4": {
       "result": "Economy understand part hair trade model.",
-      "shortResult": [
-        "Economy understand part hair trade..."
-      ]
+      "shortResult": ["Economy understand part hair trade..."]
     }
   },
   {
     "5": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Economy understand part hair trade model.\n\nDoes model result E capture all important information from gold standard E?",
         "self": {
@@ -101,9 +88,7 @@
       "cls": "FakeAgent",
       "name": "classify",
       "parent": 3,
-      "shortArgs": [
-        "Compare the following results from..."
-      ]
+      "shortArgs": ["Compare the following results from..."]
     }
   },
   {
@@ -115,9 +100,7 @@
         },
         null
       ],
-      "shortResult": [
-        "0.6324400348948942"
-      ]
+      "shortResult": ["0.6324400348948942"]
     }
   },
   {
@@ -127,9 +110,7 @@
         "missing_info": "Economy understand part hair trade model.",
         "p_complete": 0.6324400348948942
       },
-      "shortResult": [
-        "Economy understand part hair trade..."
-      ]
+      "shortResult": ["Economy understand part hair trade..."]
     }
   },
   {
@@ -146,9 +127,7 @@
       "cls": "EvaluateResult",
       "name": "run",
       "parent": 2,
-      "shortArgs": [
-        "The placebo consisted of chloroquin..."
-      ]
+      "shortArgs": ["The placebo consisted of chloroquin..."]
     }
   },
   {
@@ -166,26 +145,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 6,
-      "shortArgs": [
-        "Compare the following results from..."
-      ]
+      "shortArgs": ["Compare the following results from..."]
     }
   },
   {
     "7": {
       "result": "Card deal front key wonder career.",
-      "shortResult": [
-        "Card deal front key wonder career."
-      ]
+      "shortResult": ["Card deal front key wonder career."]
     }
   },
   {
     "8": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Card deal front key wonder career.\n\nDoes model result E capture all important information from gold standard E?",
         "self": {
@@ -196,9 +168,7 @@
       "cls": "FakeAgent",
       "name": "classify",
       "parent": 6,
-      "shortArgs": [
-        "Compare the following results from..."
-      ]
+      "shortArgs": ["Compare the following results from..."]
     }
   },
   {
@@ -210,9 +180,7 @@
         },
         null
       ],
-      "shortResult": [
-        "0.6254567461490756"
-      ]
+      "shortResult": ["0.6254567461490756"]
     }
   },
   {
@@ -222,9 +190,7 @@
         "missing_info": "Card deal front key wonder career.",
         "p_complete": 0.6254567461490756
       },
-      "shortResult": [
-        "Card deal front key wonder career."
-      ]
+      "shortResult": ["Card deal front key wonder career."]
     }
   },
   {
@@ -241,9 +207,7 @@
       "cls": "EvaluateResult",
       "name": "run",
       "parent": 2,
-      "shortArgs": [
-        "The placebo was a fake treatment th..."
-      ]
+      "shortArgs": ["The placebo was a fake treatment th..."]
     }
   },
   {
@@ -261,26 +225,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 9,
-      "shortArgs": [
-        "Compare the following results from..."
-      ]
+      "shortArgs": ["Compare the following results from..."]
     }
   },
   {
     "10": {
       "result": "Company show in someone require price decade most.",
-      "shortResult": [
-        "Company show in someone require pri..."
-      ]
+      "shortResult": ["Company show in someone require pri..."]
     }
   },
   {
     "11": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": "Compare the following results from a machine learning model to a gold standard. What (if any) information is in the gold standard but not in the model result? Does the model result capture all important information from the gold standard? Yes or No.\n\n###\n\nQuestion A: What was the placebo in this study?\n\nGold standard result A: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nModel result A: The placebo was made by the same manufacturer as the active capsules.\n\nWhat (if any) information is in gold standard A but not in model result A?\n- The specific composition of the placebo gelatin capsules (starch, talcum, kaolin, sucrose, and colouring)\n- The fact that the placebo capsules could not be distinguished from the active capsules by sight\n\nDoes model result A capture all important information from gold standard A? No\n\n###\n\nQuestion B: What was the image processing method?\n\nGold standard result B: The images were cleaned and aligned using common methods. The brain activity was measured using a statistical model that compared different types of stimuli (faces, houses, chairs, words, numbers, and a blank screen).\n\nModel result B: The images were preprocessed using a standard pipeline that included skull stripping, motion correction, spatial normalization, and smoothing. The functional data were analyzed using a general linear model (GLM) with six task conditions (face, house, chair, word, number, and fixation) as regressors of interest and six motion parameters as nuisance regressors.\n\nWhat (if any) information is in gold standard B but not in model result B? None\n\nDoes model result B capture all important information from gold standard B? Yes\n\n###\n\nQuestion C: What was the test battery?\n\nGold standard result C: The participants completed a battery of neuropsychological tests that assessed memory, attention, executive function, language, and visuospatial skills. The scores were adjusted for age and education. They were expressed as standard deviations from the average.\n\nModel result C: The participants took a series of tests that measured different aspects of their cognitive abilities, such as remembering words, repeating numbers, switching tasks, naming objects, and drawing a clock.\n\nWhat (if any) information is in gold standard C but not in model result C?\n- The analysis of test scores (adjusted for age and education, expressed as standard deviations from the average)\n\nDoes model result C capture all important information from gold standard C? No\n\n###\n\nQuestion D: What was the study design?\n\nGold standard result D: The study used a randomized controlled trial design with four groups: a group that learned mindfulness techniques, a group that learned cognitive strategies, a group that learned both, and a group that received no treatment. The interventions lasted for eight weeks and consisted of meditation, yoga, cognitive exercises, and coping skills.\n\nModel result D: The participants were randomly assigned to one of four groups: a mindfulness-based stress reduction (MBSR) group, a cognitive-behavioral therapy (CBT) group, a combination of MBSR and CBT (MBSR+CBT) group, or a wait-list control group. The MBSR group received eight weekly sessions of mindfulness meditation and yoga, the CBT group received eight weekly sessions of cognitive restructuring and coping skills training, and the MBSR+CBT group received both interventions.\n\nWhat (if any) information is in gold standard D but not in model result D? None\n\nDoes model result D capture all important information from gold standard D? Yes\n\n###\n\nQuestion E: What was the placebo in the study?\n\nGold standard result E: The placebo is the treatment given to the control group that is designed to be indistinguishable from the real treatment but has no real effect. So in this case, the placebo for Group 5 would be chloroquine, proguanil, iron and folic acid pills that look identical to the real pills but contain no active ingredients. So the subjects would think they are taking the real treatment but are actually taking inactive pills.\n\nModel result E: Placebo gelatin capsules made of starch, talcum, kaolin, sucrose, and colouring. They were made by the same manufacturer as the active capsules and could not be distinguished from the active capsules by sight\n\nWhat (if any) information is in gold standard E but not in model result E? Company show in someone require price decade most.\n\nDoes model result E capture all important information from gold standard E?",
         "self": {
@@ -291,9 +248,7 @@
       "cls": "FakeAgent",
       "name": "classify",
       "parent": 9,
-      "shortArgs": [
-        "Compare the following results from..."
-      ]
+      "shortArgs": ["Compare the following results from..."]
     }
   },
   {
@@ -305,9 +260,7 @@
         },
         null
       ],
-      "shortResult": [
-        "0.9085700657138878"
-      ]
+      "shortResult": ["0.9085700657138878"]
     }
   },
   {
@@ -317,9 +270,7 @@
         "missing_info": "Company show in someone require price decade most.",
         "p_complete": 0.9085700657138878
       },
-      "shortResult": [
-        "Company show in someone require pri..."
-      ]
+      "shortResult": ["Company show in someone require pri..."]
     }
   },
   {
@@ -341,17 +292,13 @@
           "p_complete": 0.9085700657138878
         }
       ],
-      "shortResult": [
-        "Economy understand part hair trade..."
-      ]
+      "shortResult": ["Economy understand part hair trade..."]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/ExampleMetaRecipe.json
+++ b/tests/expected_traces/ExampleMetaRecipe.json
@@ -1,0 +1,86 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": null,
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "ExampleMetaRecipe"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "self": {
+          "class_name": "ExampleMetaRecipe",
+          "mode": "test"
+        }
+      },
+      "cls": "ExampleMetaRecipe",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "()"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "input": [
+          "MetaRecipe"
+        ],
+        "self": {
+          "class_name": "MesaRecipe",
+          "mode": "test"
+        }
+      },
+      "cls": "MesaRecipe",
+      "name": "run",
+      "parent": 2,
+      "shortArgs": [
+        "MetaRecipe"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [
+        "MetaRecipe",
+        "MesaRecipe.first_node",
+        "MesaRecipe.second_node"
+      ],
+      "shortResult": [
+        "MetaRecipe",
+        "MesaRecipe.first_node",
+        "MesaRecipe.second_node"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "MetaRecipe ---> MesaRecipe.first_node ---> MesaRecipe.second_node ---> MetaRecipe.collect_result",
+      "shortResult": [
+        "MetaRecipe ---> MesaRecipe.first_no..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/ExampleMetaRecipe.json
+++ b/tests/expected_traces/ExampleMetaRecipe.json
@@ -13,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -29,17 +27,13 @@
       "cls": "ExampleMetaRecipe",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "()"
-      ]
+      "shortArgs": ["()"]
     }
   },
   {
     "3": {
       "args": {
-        "input": [
-          "MetaRecipe"
-        ],
+        "input": ["MetaRecipe"],
         "self": {
           "class_name": "MesaRecipe",
           "mode": "test"
@@ -48,39 +42,25 @@
       "cls": "MesaRecipe",
       "name": "run",
       "parent": 2,
-      "shortArgs": [
-        "MetaRecipe"
-      ]
+      "shortArgs": ["MetaRecipe"]
     }
   },
   {
     "3": {
-      "result": [
-        "MetaRecipe",
-        "MesaRecipe.first_node",
-        "MesaRecipe.second_node"
-      ],
-      "shortResult": [
-        "MetaRecipe",
-        "MesaRecipe.first_node",
-        "MesaRecipe.second_node"
-      ]
+      "result": ["MetaRecipe", "MesaRecipe.first_node", "MesaRecipe.second_node"],
+      "shortResult": ["MetaRecipe", "MesaRecipe.first_node", "MesaRecipe.second_node"]
     }
   },
   {
     "2": {
       "result": "MetaRecipe ---> MesaRecipe.first_node ---> MesaRecipe.second_node ---> MetaRecipe.collect_result",
-      "shortResult": [
-        "MetaRecipe ---> MesaRecipe.first_no..."
-      ]
+      "shortResult": ["MetaRecipe ---> MesaRecipe.first_no..."]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/ExampleMetaRecipe.json
+++ b/tests/expected_traces/ExampleMetaRecipe.json
@@ -13,7 +13,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -27,13 +29,17 @@
       "cls": "ExampleMetaRecipe",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["()"]
+      "shortArgs": [
+        "()"
+      ]
     }
   },
   {
     "3": {
       "args": {
-        "input": ["MetaRecipe"],
+        "input": [
+          "MetaRecipe"
+        ],
         "self": {
           "class_name": "MesaRecipe",
           "mode": "test"
@@ -42,25 +48,39 @@
       "cls": "MesaRecipe",
       "name": "run",
       "parent": 2,
-      "shortArgs": ["MetaRecipe"]
+      "shortArgs": [
+        "MetaRecipe"
+      ]
     }
   },
   {
     "3": {
-      "result": ["MetaRecipe", "MesaRecipe.first_node", "MesaRecipe.second_node"],
-      "shortResult": ["MetaRecipe", "MesaRecipe.first_node", "MesaRecipe.second_node"]
+      "result": [
+        "MetaRecipe",
+        "MesaRecipe.first_node",
+        "MesaRecipe.second_node"
+      ],
+      "shortResult": [
+        "MetaRecipe",
+        "MesaRecipe.first_node",
+        "MesaRecipe.second_node"
+      ]
     }
   },
   {
     "2": {
       "result": "MetaRecipe ---> MesaRecipe.first_node ---> MesaRecipe.second_node ---> MetaRecipe.collect_result",
-      "shortResult": ["MetaRecipe ---> MesaRecipe.first_no..."]
+      "shortResult": [
+        "MetaRecipe ---> MesaRecipe.first_no..."
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/FunnelSimple.json
+++ b/tests/expected_traces/FunnelSimple.json
@@ -4,7 +4,9 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": ["./papers/keenan-2018-tiny.txt"],
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -13,7 +15,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -31,7 +35,9 @@
       "cls": "FunnelSimple",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -49,19 +55,25 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": ["Summarize the adherence rate of thi..."]
+      "shortArgs": [
+        "Summarize the adherence rate of thi..."
+      ]
     }
   },
   {
     "3": {
       "result": "Support page teacher expert.",
-      "shortResult": ["Support page teacher expert."]
+      "shortResult": [
+        "Support page teacher expert."
+      ]
     }
   },
   {
     "2": {
       "result": "Support page teacher expert.",
-      "shortResult": ["Support page teacher expert."]
+      "shortResult": [
+        "Support page teacher expert."
+      ]
     }
   },
   {
@@ -76,7 +88,9 @@
       "cls": "FunnelSimple",
       "name": "evaluation_report",
       "parent": 1,
-      "shortArgs": ["()"]
+      "shortArgs": [
+        "()"
+      ]
     }
   },
   {
@@ -87,7 +101,10 @@
             "answer": "Support page teacher expert.",
             "answer_rating": null,
             "classification_eq": [],
-            "classifications": [null, null],
+            "classifications": [
+              null,
+              null
+            ],
             "document_id": "keenan-2018.pdf",
             "elicit_commit": null,
             "evaluated_excerpts": {
@@ -105,7 +122,10 @@
             "failure_modes": null,
             "gold_standard": {
               "answer": "Azithromycin was administered to 90% of participants.",
-              "classifications": ["explicit", null],
+              "classifications": [
+                "explicit",
+                null
+              ],
               "document_id": "keenan-2018.pdf",
               "experiment": "Oral azithromycin for childhood mortality",
               "question_short_name": "adherence",
@@ -120,13 +140,17 @@
         ],
         "technique_name": "FunnelSimple"
       },
-      "shortResult": ["FunnelSimple"]
+      "shortResult": [
+        "FunnelSimple"
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/FunnelSimple.json
+++ b/tests/expected_traces/FunnelSimple.json
@@ -4,9 +4,7 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": [
-          "./papers/keenan-2018-tiny.txt"
-        ],
+        "input_files": ["./papers/keenan-2018-tiny.txt"],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -15,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -35,9 +31,7 @@
       "cls": "FunnelSimple",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -55,25 +49,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": [
-        "Summarize the adherence rate of thi..."
-      ]
+      "shortArgs": ["Summarize the adherence rate of thi..."]
     }
   },
   {
     "3": {
       "result": "Support page teacher expert.",
-      "shortResult": [
-        "Support page teacher expert."
-      ]
+      "shortResult": ["Support page teacher expert."]
     }
   },
   {
     "2": {
       "result": "Support page teacher expert.",
-      "shortResult": [
-        "Support page teacher expert."
-      ]
+      "shortResult": ["Support page teacher expert."]
     }
   },
   {
@@ -88,9 +76,7 @@
       "cls": "FunnelSimple",
       "name": "evaluation_report",
       "parent": 1,
-      "shortArgs": [
-        "()"
-      ]
+      "shortArgs": ["()"]
     }
   },
   {
@@ -101,10 +87,7 @@
             "answer": "Support page teacher expert.",
             "answer_rating": null,
             "classification_eq": [],
-            "classifications": [
-              null,
-              null
-            ],
+            "classifications": [null, null],
             "document_id": "keenan-2018.pdf",
             "elicit_commit": null,
             "evaluated_excerpts": {
@@ -122,10 +105,7 @@
             "failure_modes": null,
             "gold_standard": {
               "answer": "Azithromycin was administered to 90% of participants.",
-              "classifications": [
-                "explicit",
-                null
-              ],
+              "classifications": ["explicit", null],
               "document_id": "keenan-2018.pdf",
               "experiment": "Oral azithromycin for childhood mortality",
               "question_short_name": "adherence",
@@ -140,17 +120,13 @@
         ],
         "technique_name": "FunnelSimple"
       },
-      "shortResult": [
-        "FunnelSimple"
-      ]
+      "shortResult": ["FunnelSimple"]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/FunnelSimple.json
+++ b/tests/expected_traces/FunnelSimple.json
@@ -1,0 +1,156 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "FunnelSimple"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "self": {
+          "agent_str": "instruct",
+          "class_name": "FunnelSimple",
+          "mode": "test"
+        }
+      },
+      "cls": "FunnelSimple",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "default": "",
+        "max_tokens": 500,
+        "prompt": "Summarize the adherence rate of this research paper based on the following excerpt. If the adherence rate is not mentioned in this excerpt, say \"not mentioned\".\n\nBEGIN PAPER EXCERPT\n\nIn this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo. Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial. Vital status was determined at subsequent censuses. The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses. Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger. Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance. (Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)\n\nTrachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17\n\nMORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.\n\nLists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF). For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org). Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing). Only key trial personnel were aware of which letters corresponded to each group. Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments. Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments. The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin. Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial.\n\nEach child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.\n\nThe results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups. At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania). Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001). The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively).\n\nEND PAPER EXCERPT\n\nOne possible summary of the adherence rate based on the above excerpt is:",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 2,
+      "shortArgs": [
+        "Summarize the adherence rate of thi..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": "Support page teacher expert.",
+      "shortResult": [
+        "Support page teacher expert."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Support page teacher expert.",
+      "shortResult": [
+        "Support page teacher expert."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "self": {
+          "agent_str": "instruct",
+          "class_name": "FunnelSimple",
+          "mode": "test"
+        }
+      },
+      "cls": "FunnelSimple",
+      "name": "evaluation_report",
+      "parent": 1,
+      "shortArgs": [
+        "()"
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": {
+        "results": [
+          {
+            "answer": "Support page teacher expert.",
+            "answer_rating": null,
+            "classification_eq": [],
+            "classifications": [
+              null,
+              null
+            ],
+            "document_id": "keenan-2018.pdf",
+            "elicit_commit": null,
+            "evaluated_excerpts": {
+              "average_recall": 0.0,
+              "excerpts": [],
+              "gold_standards_in_excerpts_results": [
+                {
+                  "found": false,
+                  "text": "Azithromycin was administered to a mean (\u00b1SD) of 90.3\u00b110.6% of the targeted population, and placebo was administered to 90.4\u00b110.1% (see the Supplementary Appendix)."
+                }
+              ]
+            },
+            "excerpts": [],
+            "experiment": "Oral azithromycin for childhood mortality",
+            "failure_modes": null,
+            "gold_standard": {
+              "answer": "Azithromycin was administered to 90% of participants.",
+              "classifications": [
+                "explicit",
+                null
+              ],
+              "document_id": "keenan-2018.pdf",
+              "experiment": "Oral azithromycin for childhood mortality",
+              "question_short_name": "adherence",
+              "quotes": [
+                "Azithromycin was administered to a mean (\u00b1SD) of 90.3\u00b110.6% of the targeted population, and placebo was administered to 90.4\u00b110.1% (see the Supplementary Appendix)."
+              ],
+              "split": "iterate"
+            },
+            "question_short_name": "adherence",
+            "result": "Support page teacher expert."
+          }
+        ],
+        "technique_name": "FunnelSimple"
+      },
+      "shortResult": [
+        "FunnelSimple"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/PlaceboDescriptionInstruct.json
+++ b/tests/expected_traces/PlaceboDescriptionInstruct.json
@@ -4,7 +4,9 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": ["./papers/keenan-2018-tiny.txt"],
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -13,7 +15,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -36,7 +40,9 @@
       "cls": "PlaceboDescriptionInstruct",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -55,25 +61,35 @@
       "cls": "PlaceboDescriptionInstruct",
       "name": "get_gold_experiments",
       "parent": 2,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
     "3": {
-      "result": ["Oral azithromycin for childhood mortality"],
-      "shortResult": ["Oral azithromycin for childhood mor..."]
+      "result": [
+        "Oral azithromycin for childhood mortality"
+      ],
+      "shortResult": [
+        "Oral azithromycin for childhood mor..."
+      ]
     }
   },
   {
     "2": {
       "result": {},
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/PlaceboDescriptionInstruct.json
+++ b/tests/expected_traces/PlaceboDescriptionInstruct.json
@@ -4,9 +4,7 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": [
-          "./papers/keenan-2018-tiny.txt"
-        ],
+        "input_files": ["./papers/keenan-2018-tiny.txt"],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -15,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -40,9 +36,7 @@
       "cls": "PlaceboDescriptionInstruct",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -61,35 +55,25 @@
       "cls": "PlaceboDescriptionInstruct",
       "name": "get_gold_experiments",
       "parent": 2,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
     "3": {
-      "result": [
-        "Oral azithromycin for childhood mortality"
-      ],
-      "shortResult": [
-        "Oral azithromycin for childhood mor..."
-      ]
+      "result": ["Oral azithromycin for childhood mortality"],
+      "shortResult": ["Oral azithromycin for childhood mor..."]
     }
   },
   {
     "2": {
       "result": {},
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/PlaceboDescriptionInstruct.json
+++ b/tests/expected_traces/PlaceboDescriptionInstruct.json
@@ -1,0 +1,95 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "PlaceboDescriptionInstruct"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "record": {
+          "class_name": "function",
+          "name": "<lambda>"
+        },
+        "self": {
+          "agent_str": "instruct",
+          "class_name": "PlaceboDescriptionInstruct",
+          "mode": "test",
+          "name": "PlaceboDescriptionInstruct"
+        }
+      },
+      "cls": "PlaceboDescriptionInstruct",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "self": {
+          "agent_str": "instruct",
+          "class_name": "PlaceboDescriptionInstruct",
+          "mode": "test",
+          "name": "PlaceboDescriptionInstruct"
+        }
+      },
+      "cls": "PlaceboDescriptionInstruct",
+      "name": "get_gold_experiments",
+      "parent": 2,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [
+        "Oral azithromycin for childhood mortality"
+      ],
+      "shortResult": [
+        "Oral azithromycin for childhood mor..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": {},
+      "shortResult": [
+        "()"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/PlaceboKeywordBaseline.json
+++ b/tests/expected_traces/PlaceboKeywordBaseline.json
@@ -1,0 +1,58 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "PlaceboKeywordBaseline"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "self": {
+          "class_name": "PlaceboKeywordBaseline",
+          "mode": "test"
+        }
+      },
+      "cls": "PlaceboKeywordBaseline",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [],
+      "shortResult": [
+        "()"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/PlaceboKeywordBaseline.json
+++ b/tests/expected_traces/PlaceboKeywordBaseline.json
@@ -4,9 +4,7 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": [
-          "./papers/keenan-2018-tiny.txt"
-        ],
+        "input_files": ["./papers/keenan-2018-tiny.txt"],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -15,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -34,25 +30,19 @@
       "cls": "PlaceboKeywordBaseline",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
     "2": {
       "result": [],
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/PlaceboKeywordBaseline.json
+++ b/tests/expected_traces/PlaceboKeywordBaseline.json
@@ -4,7 +4,9 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": ["./papers/keenan-2018-tiny.txt"],
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -13,7 +15,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -30,19 +34,25 @@
       "cls": "PlaceboKeywordBaseline",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
     "2": {
       "result": [],
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/PlaceboSimpleInstruct.json
+++ b/tests/expected_traces/PlaceboSimpleInstruct.json
@@ -1,0 +1,164 @@
+[
+  {
+    "1": {
+      "args": {
+        "args": {},
+        "gold_standard_splits": null,
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
+        "json_out": null,
+        "mode": "test",
+        "output_file": null,
+        "question_short_name": null,
+        "recipe_name": "PlaceboSimpleInstruct"
+      },
+      "name": "main",
+      "parent": 0,
+      "shortArgs": [
+        "test"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "self": {
+          "agent_str": "instruct",
+          "class_name": "PlaceboSimpleInstruct",
+          "default_answer_classification": "Placebo",
+          "max_tokens": 3500,
+          "mode": "test",
+          "qa_prompt_template": "\n\nHuman: What is a placebo-controlled study?\n\nAssistant: A placebo-controlled study is a way of testing a treatment in which a separate control group receives a sham \"placebo\" treatment which is specifically designed to be indistinguishable from the real treatment but has no real effect.\n\nHuman: Here's the text of a paper I've been thinking about:\n\n{paper_text}\n\nAssistant: I've read it thoroughly and can answer any question you may have about it.\n\nHuman: Was this a placebo-controlled study? Say \"yes\", \"no\", or \"unclear\".\n\nAssistant: Let's think step by step:",
+          "question_short_name": "placebo"
+        }
+      },
+      "cls": "PlaceboSimpleInstruct",
+      "name": "run",
+      "parent": 1,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "default": "",
+        "max_tokens": 300,
+        "prompt": "\n\nHuman: What is a placebo-controlled study?\n\nAssistant: A placebo-controlled study is a way of testing a treatment in which a separate control group receives a sham \"placebo\" treatment which is specifically designed to be indistinguishable from the real treatment but has no real effect.\n\nHuman: Here's the text of a paper I've been thinking about:\n\nIn this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo. Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial. Vital status was determined at subsequent censuses. The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses. Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger. Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance. (Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)\n\nTrachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17\n\nMORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.\n\nLists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF). For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org). Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing). Only key trial personnel were aware of which letters corresponded to each group. Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments. Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments. The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin. Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial.\n\nEach child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.\n\nThe results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups. At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania). Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001). The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively).\n\nAssistant: I've read it thoroughly and can answer any question you may have about it.\n\nHuman: Was this a placebo-controlled study? Say \"yes\", \"no\", or \"unclear\".\n\nAssistant: Let's think step by step:",
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 2,
+      "shortArgs": [
+        "Human: What is a placebo-controll..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": "Hold kid fall we somebody determine father.",
+      "shortResult": [
+        "Hold kid fall we somebody determine..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Hold kid fall we somebody determine father.",
+      "shortResult": [
+        "Hold kid fall we somebody determine..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "self": {
+          "agent_str": "instruct",
+          "class_name": "PlaceboSimpleInstruct",
+          "default_answer_classification": "Placebo",
+          "max_tokens": 3500,
+          "mode": "test",
+          "qa_prompt_template": "\n\nHuman: What is a placebo-controlled study?\n\nAssistant: A placebo-controlled study is a way of testing a treatment in which a separate control group receives a sham \"placebo\" treatment which is specifically designed to be indistinguishable from the real treatment but has no real effect.\n\nHuman: Here's the text of a paper I've been thinking about:\n\n{paper_text}\n\nAssistant: I've read it thoroughly and can answer any question you may have about it.\n\nHuman: Was this a placebo-controlled study? Say \"yes\", \"no\", or \"unclear\".\n\nAssistant: Let's think step by step:",
+          "question_short_name": "placebo"
+        }
+      },
+      "cls": "PlaceboSimpleInstruct",
+      "name": "evaluation_report",
+      "parent": 1,
+      "shortArgs": [
+        "()"
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": {
+        "results": [
+          {
+            "answer": "Hold kid fall we somebody determine father.",
+            "answer_rating": null,
+            "classification_eq": [],
+            "classifications": [
+              "Placebo",
+              "Placebo"
+            ],
+            "document_id": "keenan-2018.pdf",
+            "elicit_commit": null,
+            "evaluated_excerpts": {
+              "average_recall": 0.0,
+              "excerpts": [],
+              "gold_standards_in_excerpts_results": [
+                {
+                  "found": false,
+                  "text": "The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin."
+                }
+              ]
+            },
+            "excerpts": [],
+            "experiment": "Oral azithromycin for childhood mortality",
+            "failure_modes": null,
+            "gold_standard": {
+              "answer": "the vehicle of the oral azithromycin suspension, bottled and labeled identically to azithromycin",
+              "classifications": [
+                "Placebo",
+                "Placebo"
+              ],
+              "document_id": "keenan-2018.pdf",
+              "experiment": "Oral azithromycin for childhood mortality",
+              "question_short_name": "placebo",
+              "quotes": [
+                "The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin."
+              ],
+              "split": "iterate"
+            },
+            "question_short_name": "placebo",
+            "result": "Hold kid fall we somebody determine father."
+          }
+        ],
+        "technique_name": "PlaceboSimpleInstruct"
+      },
+      "shortResult": [
+        "PlaceboSimpleInstruct"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": null,
+      "shortResult": [
+        "()"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/PlaceboSimpleInstruct.json
+++ b/tests/expected_traces/PlaceboSimpleInstruct.json
@@ -4,9 +4,7 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": [
-          "./papers/keenan-2018-tiny.txt"
-        ],
+        "input_files": ["./papers/keenan-2018-tiny.txt"],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -15,9 +13,7 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": [
-        "test"
-      ]
+      "shortArgs": ["test"]
     }
   },
   {
@@ -39,9 +35,7 @@
       "cls": "PlaceboSimpleInstruct",
       "name": "run",
       "parent": 1,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -59,25 +53,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": [
-        "Human: What is a placebo-controll..."
-      ]
+      "shortArgs": ["Human: What is a placebo-controll..."]
     }
   },
   {
     "3": {
       "result": "Hold kid fall we somebody determine father.",
-      "shortResult": [
-        "Hold kid fall we somebody determine..."
-      ]
+      "shortResult": ["Hold kid fall we somebody determine..."]
     }
   },
   {
     "2": {
       "result": "Hold kid fall we somebody determine father.",
-      "shortResult": [
-        "Hold kid fall we somebody determine..."
-      ]
+      "shortResult": ["Hold kid fall we somebody determine..."]
     }
   },
   {
@@ -96,9 +84,7 @@
       "cls": "PlaceboSimpleInstruct",
       "name": "evaluation_report",
       "parent": 1,
-      "shortArgs": [
-        "()"
-      ]
+      "shortArgs": ["()"]
     }
   },
   {
@@ -109,10 +95,7 @@
             "answer": "Hold kid fall we somebody determine father.",
             "answer_rating": null,
             "classification_eq": [],
-            "classifications": [
-              "Placebo",
-              "Placebo"
-            ],
+            "classifications": ["Placebo", "Placebo"],
             "document_id": "keenan-2018.pdf",
             "elicit_commit": null,
             "evaluated_excerpts": {
@@ -130,10 +113,7 @@
             "failure_modes": null,
             "gold_standard": {
               "answer": "the vehicle of the oral azithromycin suspension, bottled and labeled identically to azithromycin",
-              "classifications": [
-                "Placebo",
-                "Placebo"
-              ],
+              "classifications": ["Placebo", "Placebo"],
               "document_id": "keenan-2018.pdf",
               "experiment": "Oral azithromycin for childhood mortality",
               "question_short_name": "placebo",
@@ -148,17 +128,13 @@
         ],
         "technique_name": "PlaceboSimpleInstruct"
       },
-      "shortResult": [
-        "PlaceboSimpleInstruct"
-      ]
+      "shortResult": ["PlaceboSimpleInstruct"]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": [
-        "()"
-      ]
+      "shortResult": ["()"]
     }
   }
 ]

--- a/tests/expected_traces/PlaceboSimpleInstruct.json
+++ b/tests/expected_traces/PlaceboSimpleInstruct.json
@@ -4,7 +4,9 @@
       "args": {
         "args": {},
         "gold_standard_splits": null,
-        "input_files": ["./papers/keenan-2018-tiny.txt"],
+        "input_files": [
+          "./papers/keenan-2018-tiny.txt"
+        ],
         "json_out": null,
         "mode": "test",
         "output_file": null,
@@ -13,7 +15,9 @@
       },
       "name": "main",
       "parent": 0,
-      "shortArgs": ["test"]
+      "shortArgs": [
+        "test"
+      ]
     }
   },
   {
@@ -35,7 +39,9 @@
       "cls": "PlaceboSimpleInstruct",
       "name": "run",
       "parent": 1,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -53,19 +59,25 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": ["Human: What is a placebo-controll..."]
+      "shortArgs": [
+        "Human: What is a placebo-controll..."
+      ]
     }
   },
   {
     "3": {
       "result": "Hold kid fall we somebody determine father.",
-      "shortResult": ["Hold kid fall we somebody determine..."]
+      "shortResult": [
+        "Hold kid fall we somebody determine..."
+      ]
     }
   },
   {
     "2": {
       "result": "Hold kid fall we somebody determine father.",
-      "shortResult": ["Hold kid fall we somebody determine..."]
+      "shortResult": [
+        "Hold kid fall we somebody determine..."
+      ]
     }
   },
   {
@@ -84,7 +96,9 @@
       "cls": "PlaceboSimpleInstruct",
       "name": "evaluation_report",
       "parent": 1,
-      "shortArgs": ["()"]
+      "shortArgs": [
+        "()"
+      ]
     }
   },
   {
@@ -95,7 +109,10 @@
             "answer": "Hold kid fall we somebody determine father.",
             "answer_rating": null,
             "classification_eq": [],
-            "classifications": ["Placebo", "Placebo"],
+            "classifications": [
+              "Placebo",
+              "Placebo"
+            ],
             "document_id": "keenan-2018.pdf",
             "elicit_commit": null,
             "evaluated_excerpts": {
@@ -113,7 +130,10 @@
             "failure_modes": null,
             "gold_standard": {
               "answer": "the vehicle of the oral azithromycin suspension, bottled and labeled identically to azithromycin",
-              "classifications": ["Placebo", "Placebo"],
+              "classifications": [
+                "Placebo",
+                "Placebo"
+              ],
               "document_id": "keenan-2018.pdf",
               "experiment": "Oral azithromycin for childhood mortality",
               "question_short_name": "placebo",
@@ -128,13 +148,17 @@
         ],
         "technique_name": "PlaceboSimpleInstruct"
       },
-      "shortResult": ["PlaceboSimpleInstruct"]
+      "shortResult": [
+        "PlaceboSimpleInstruct"
+      ]
     }
   },
   {
     "1": {
       "result": null,
-      "shortResult": ["()"]
+      "shortResult": [
+        "()"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer0].json
@@ -1,0 +1,69 @@
+[
+  {
+    "1": {
+      "args": {
+        "context": "We're running a hackathon on 9/9/2022 to decompose complex reasoning tasks into subtasks that are easier to automate & evaluate with language models. Our team is currently breaking down reasoning about the quality of evidence in randomized controlled trials into smaller tasks e.g. placebo, intervention adherence rate, blinding procedure, etc.",
+        "question": "What is happening on 9/9/2022?"
+      },
+      "name": "answer",
+      "parent": 0,
+      "shortArgs": [
+        "We're running a hackathon on 9/9/20..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Background text: \"",
+            {
+              "formatted": "We're running a hackathon on 9/9/2022 to decompose complex reasoning tasks into subtasks that are easier to automate & evaluate with language models. Our team is currently breaking down reasoning about the quality of evidence in randomized controlled trials into smaller tasks e.g. placebo, intervention adherence rate, blinding procedure, etc.",
+              "source": "context",
+              "value": "We're running a hackathon on 9/9/2022 to decompose complex reasoning tasks into subtasks that are easier to automate & evaluate with language models. Our team is currently breaking down reasoning about the quality of evidence in randomized controlled trials into smaller tasks e.g. placebo, intervention adherence rate, blinding procedure, etc."
+            },
+            "\"\n\nAnswer the following question about the background text above:\n\nQuestion: \"",
+            {
+              "formatted": "What is happening on 9/9/2022?",
+              "source": "question",
+              "value": "What is happening on 9/9/2022?"
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 1,
+      "shortArgs": [
+        "Background text: \"",
+        "\"\n\nAnswer the following question ab...",
+        "\"\nAnswer: \""
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Impact such raise rock include reveal product.",
+      "shortResult": [
+        "Impact such raise rock include reve..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Impact such raise rock include reveal product.",
+      "shortResult": [
+        "Impact such raise rock include reve..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer0].json
@@ -7,7 +7,9 @@
       },
       "name": "answer",
       "parent": 0,
-      "shortArgs": ["We're running a hackathon on 9/9/20..."]
+      "shortArgs": [
+        "We're running a hackathon on 9/9/20..."
+      ]
     }
   },
   {
@@ -51,13 +53,17 @@
   {
     "2": {
       "result": "Impact such raise rock include reveal product.",
-      "shortResult": ["Impact such raise rock include reve..."]
+      "shortResult": [
+        "Impact such raise rock include reve..."
+      ]
     }
   },
   {
     "1": {
       "result": "Impact such raise rock include reveal product.",
-      "shortResult": ["Impact such raise rock include reve..."]
+      "shortResult": [
+        "Impact such raise rock include reve..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer0].json
@@ -7,9 +7,7 @@
       },
       "name": "answer",
       "parent": 0,
-      "shortArgs": [
-        "We're running a hackathon on 9/9/20..."
-      ]
+      "shortArgs": ["We're running a hackathon on 9/9/20..."]
     }
   },
   {
@@ -53,17 +51,13 @@
   {
     "2": {
       "result": "Impact such raise rock include reveal product.",
-      "shortResult": [
-        "Impact such raise rock include reve..."
-      ]
+      "shortResult": ["Impact such raise rock include reve..."]
     }
   },
   {
     "1": {
       "result": "Impact such raise rock include reveal product.",
-      "shortResult": [
-        "Impact such raise rock include reve..."
-      ]
+      "shortResult": ["Impact such raise rock include reve..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer1].json
@@ -1,0 +1,61 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "What is happening on 9/9/2022?"
+      },
+      "name": "answer",
+      "parent": 0,
+      "shortArgs": [
+        "What is happening on 9/9/2022?"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Answer the following question:\n\nQuestion: \"",
+            {
+              "formatted": "What is happening on 9/9/2022?",
+              "source": "question",
+              "value": "What is happening on 9/9/2022?"
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 1,
+      "shortArgs": [
+        "Answer the following question:\n\nQue...",
+        "\"\nAnswer: \""
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "History politics focus though believe country difference.",
+      "shortResult": [
+        "History politics focus though belie..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "History politics focus though believe country difference.",
+      "shortResult": [
+        "History politics focus though belie..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer1].json
@@ -6,9 +6,7 @@
       },
       "name": "answer",
       "parent": 0,
-      "shortArgs": [
-        "What is happening on 9/9/2022?"
-      ]
+      "shortArgs": ["What is happening on 9/9/2022?"]
     }
   },
   {
@@ -36,26 +34,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 1,
-      "shortArgs": [
-        "Answer the following question:\n\nQue...",
-        "\"\nAnswer: \""
-      ]
+      "shortArgs": ["Answer the following question:\n\nQue...", "\"\nAnswer: \""]
     }
   },
   {
     "2": {
       "result": "History politics focus though believe country difference.",
-      "shortResult": [
-        "History politics focus though belie..."
-      ]
+      "shortResult": ["History politics focus though belie..."]
     }
   },
   {
     "1": {
       "result": "History politics focus though believe country difference.",
-      "shortResult": [
-        "History politics focus though belie..."
-      ]
+      "shortResult": ["History politics focus though belie..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer1].json
@@ -6,7 +6,9 @@
       },
       "name": "answer",
       "parent": 0,
-      "shortArgs": ["What is happening on 9/9/2022?"]
+      "shortArgs": [
+        "What is happening on 9/9/2022?"
+      ]
     }
   },
   {
@@ -34,19 +36,26 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 1,
-      "shortArgs": ["Answer the following question:\n\nQue...", "\"\nAnswer: \""]
+      "shortArgs": [
+        "Answer the following question:\n\nQue...",
+        "\"\nAnswer: \""
+      ]
     }
   },
   {
     "2": {
       "result": "History politics focus though believe country difference.",
-      "shortResult": ["History politics focus though belie..."]
+      "shortResult": [
+        "History politics focus though belie..."
+      ]
     }
   },
   {
     "1": {
       "result": "History politics focus though believe country difference.",
-      "shortResult": ["History politics focus though belie..."]
+      "shortResult": [
+        "History politics focus though belie..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_amplification0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_amplification0].json
@@ -1,0 +1,247 @@
+[
+  {
+    "1": {
+      "args": {
+        "depth": 1,
+        "question": "What is the effect of creatine on cognition?"
+      },
+      "name": "answer_by_amplification",
+      "parent": 0,
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "depth": 0,
+        "question": "What is the effect of creatine on cognition?"
+      },
+      "name": "get_subs",
+      "parent": 1,
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "question": "What is the effect of creatine on cognition?"
+      },
+      "name": "ask_subquestions",
+      "parent": 2,
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Decompose the following question into 2-5 subquestions that would help you answer the question. Make the questions stand alone, so that they can be answered without the context of the original question.\n\nQuestion: \"",
+            {
+              "formatted": "What is the effect of creatine on cognition?",
+              "source": "question",
+              "value": "What is the effect of creatine on cognition?"
+            },
+            "\"\nSubquestions:\n-"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Decompose the following question in...",
+        "\"\nSubquestions:\n-"
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": "Moment meet decide beautiful.",
+      "shortResult": [
+        "Moment meet decide beautiful."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [
+        "Moment meet decide beautiful."
+      ],
+      "shortResult": [
+        "Moment meet decide beautiful."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "depth": 0,
+        "question": "Moment meet decide beautiful."
+      },
+      "name": "answer_by_amplification",
+      "parent": 2,
+      "shortArgs": [
+        "Moment meet decide beautiful."
+      ]
+    }
+  },
+  {
+    "6": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Answer the following question, using the background information above where helpful:\n\nQuestion: \"",
+            {
+              "formatted": "Moment meet decide beautiful.",
+              "source": "question",
+              "value": "Moment meet decide beautiful."
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 5,
+      "shortArgs": [
+        "Answer the following question, usin...",
+        "\"\nAnswer: \""
+      ]
+    }
+  },
+  {
+    "6": {
+      "result": "Happen newspaper few office model late month school.",
+      "shortResult": [
+        "Happen newspaper few office model l..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": "Happen newspaper few office model late month school.",
+      "shortResult": [
+        "Happen newspaper few office model l..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [
+        [
+          "Moment meet decide beautiful.",
+          "Happen newspaper few office model late month school."
+        ]
+      ],
+      "shortResult": [
+        "Moment meet decide beautiful.",
+        "Happen newspaper few office model l..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            {
+              "formatted": "Here is relevant background information:\n\nQ: Moment meet decide beautiful.\nA: Happen newspaper few office model late month school.\n\n",
+              "source": "background_text",
+              "value": {
+                "__fstring__": [
+                  "Here is relevant background information:\n\n",
+                  {
+                    "formatted": "Q: Moment meet decide beautiful.\nA: Happen newspaper few office model late month school.",
+                    "source": "subs_text",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "Q: Moment meet decide beautiful.\nA: Happen newspaper few office model late month school.",
+                          "source": "list((F(f\"Q: {q}\\nA: {a}\") for (q, a) in subs))[0]",
+                          "value": {
+                            "__fstring__": [
+                              "Q: ",
+                              {
+                                "formatted": "Moment meet decide beautiful.",
+                                "source": "q",
+                                "value": "Moment meet decide beautiful."
+                              },
+                              "\nA: ",
+                              {
+                                "formatted": "Happen newspaper few office model late month school.",
+                                "source": "a",
+                                "value": "Happen newspaper few office model late month school."
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "\n\n"
+                ]
+              }
+            },
+            "Answer the following question, using the background information above where helpful:\n\nQuestion: \"",
+            {
+              "formatted": "What is the effect of creatine on cognition?",
+              "source": "question",
+              "value": "What is the effect of creatine on cognition?"
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 1,
+      "shortArgs": [
+        "background_text"
+      ]
+    }
+  },
+  {
+    "7": {
+      "result": "Suggest only second against conference together.",
+      "shortResult": [
+        "Suggest only second against confere..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Suggest only second against conference together.",
+      "shortResult": [
+        "Suggest only second against confere..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_amplification0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_amplification0].json
@@ -7,7 +7,9 @@
       },
       "name": "answer_by_amplification",
       "parent": 0,
-      "shortArgs": ["What is the effect of creatine on c..."]
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
     }
   },
   {
@@ -18,7 +20,9 @@
       },
       "name": "get_subs",
       "parent": 1,
-      "shortArgs": ["What is the effect of creatine on c..."]
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
     }
   },
   {
@@ -28,7 +32,9 @@
       },
       "name": "ask_subquestions",
       "parent": 2,
-      "shortArgs": ["What is the effect of creatine on c..."]
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
     }
   },
   {
@@ -56,19 +62,28 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Decompose the following question in...", "\"\nSubquestions:\n-"]
+      "shortArgs": [
+        "Decompose the following question in...",
+        "\"\nSubquestions:\n-"
+      ]
     }
   },
   {
     "4": {
       "result": "Moment meet decide beautiful.",
-      "shortResult": ["Moment meet decide beautiful."]
+      "shortResult": [
+        "Moment meet decide beautiful."
+      ]
     }
   },
   {
     "3": {
-      "result": ["Moment meet decide beautiful."],
-      "shortResult": ["Moment meet decide beautiful."]
+      "result": [
+        "Moment meet decide beautiful."
+      ],
+      "shortResult": [
+        "Moment meet decide beautiful."
+      ]
     }
   },
   {
@@ -79,7 +94,9 @@
       },
       "name": "answer_by_amplification",
       "parent": 2,
-      "shortArgs": ["Moment meet decide beautiful."]
+      "shortArgs": [
+        "Moment meet decide beautiful."
+      ]
     }
   },
   {
@@ -107,27 +124,40 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 5,
-      "shortArgs": ["Answer the following question, usin...", "\"\nAnswer: \""]
+      "shortArgs": [
+        "Answer the following question, usin...",
+        "\"\nAnswer: \""
+      ]
     }
   },
   {
     "6": {
       "result": "Happen newspaper few office model late month school.",
-      "shortResult": ["Happen newspaper few office model l..."]
+      "shortResult": [
+        "Happen newspaper few office model l..."
+      ]
     }
   },
   {
     "5": {
       "result": "Happen newspaper few office model late month school.",
-      "shortResult": ["Happen newspaper few office model l..."]
+      "shortResult": [
+        "Happen newspaper few office model l..."
+      ]
     }
   },
   {
     "2": {
       "result": [
-        ["Moment meet decide beautiful.", "Happen newspaper few office model late month school."]
+        [
+          "Moment meet decide beautiful.",
+          "Happen newspaper few office model late month school."
+        ]
       ],
-      "shortResult": ["Moment meet decide beautiful.", "Happen newspaper few office model l..."]
+      "shortResult": [
+        "Moment meet decide beautiful.",
+        "Happen newspaper few office model l..."
+      ]
     }
   },
   {
@@ -193,19 +223,25 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 1,
-      "shortArgs": ["background_text"]
+      "shortArgs": [
+        "background_text"
+      ]
     }
   },
   {
     "7": {
       "result": "Suggest only second against conference together.",
-      "shortResult": ["Suggest only second against confere..."]
+      "shortResult": [
+        "Suggest only second against confere..."
+      ]
     }
   },
   {
     "1": {
       "result": "Suggest only second against conference together.",
-      "shortResult": ["Suggest only second against confere..."]
+      "shortResult": [
+        "Suggest only second against confere..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_amplification0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_amplification0].json
@@ -7,9 +7,7 @@
       },
       "name": "answer_by_amplification",
       "parent": 0,
-      "shortArgs": [
-        "What is the effect of creatine on c..."
-      ]
+      "shortArgs": ["What is the effect of creatine on c..."]
     }
   },
   {
@@ -20,9 +18,7 @@
       },
       "name": "get_subs",
       "parent": 1,
-      "shortArgs": [
-        "What is the effect of creatine on c..."
-      ]
+      "shortArgs": ["What is the effect of creatine on c..."]
     }
   },
   {
@@ -32,9 +28,7 @@
       },
       "name": "ask_subquestions",
       "parent": 2,
-      "shortArgs": [
-        "What is the effect of creatine on c..."
-      ]
+      "shortArgs": ["What is the effect of creatine on c..."]
     }
   },
   {
@@ -62,28 +56,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Decompose the following question in...",
-        "\"\nSubquestions:\n-"
-      ]
+      "shortArgs": ["Decompose the following question in...", "\"\nSubquestions:\n-"]
     }
   },
   {
     "4": {
       "result": "Moment meet decide beautiful.",
-      "shortResult": [
-        "Moment meet decide beautiful."
-      ]
+      "shortResult": ["Moment meet decide beautiful."]
     }
   },
   {
     "3": {
-      "result": [
-        "Moment meet decide beautiful."
-      ],
-      "shortResult": [
-        "Moment meet decide beautiful."
-      ]
+      "result": ["Moment meet decide beautiful."],
+      "shortResult": ["Moment meet decide beautiful."]
     }
   },
   {
@@ -94,9 +79,7 @@
       },
       "name": "answer_by_amplification",
       "parent": 2,
-      "shortArgs": [
-        "Moment meet decide beautiful."
-      ]
+      "shortArgs": ["Moment meet decide beautiful."]
     }
   },
   {
@@ -124,40 +107,27 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 5,
-      "shortArgs": [
-        "Answer the following question, usin...",
-        "\"\nAnswer: \""
-      ]
+      "shortArgs": ["Answer the following question, usin...", "\"\nAnswer: \""]
     }
   },
   {
     "6": {
       "result": "Happen newspaper few office model late month school.",
-      "shortResult": [
-        "Happen newspaper few office model l..."
-      ]
+      "shortResult": ["Happen newspaper few office model l..."]
     }
   },
   {
     "5": {
       "result": "Happen newspaper few office model late month school.",
-      "shortResult": [
-        "Happen newspaper few office model l..."
-      ]
+      "shortResult": ["Happen newspaper few office model l..."]
     }
   },
   {
     "2": {
       "result": [
-        [
-          "Moment meet decide beautiful.",
-          "Happen newspaper few office model late month school."
-        ]
+        ["Moment meet decide beautiful.", "Happen newspaper few office model late month school."]
       ],
-      "shortResult": [
-        "Moment meet decide beautiful.",
-        "Happen newspaper few office model l..."
-      ]
+      "shortResult": ["Moment meet decide beautiful.", "Happen newspaper few office model l..."]
     }
   },
   {
@@ -223,25 +193,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 1,
-      "shortArgs": [
-        "background_text"
-      ]
+      "shortArgs": ["background_text"]
     }
   },
   {
     "7": {
       "result": "Suggest only second against conference together.",
-      "shortResult": [
-        "Suggest only second against confere..."
-      ]
+      "shortResult": ["Suggest only second against confere..."]
     }
   },
   {
     "1": {
       "result": "Suggest only second against conference together.",
-      "shortResult": [
-        "Suggest only second against confere..."
-      ]
+      "shortResult": ["Suggest only second against confere..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_amplification1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_amplification1].json
@@ -1,0 +1,271 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "What is the effect of creatine on cognition?"
+      },
+      "name": "answer_by_amplification",
+      "parent": 0,
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "question": "What is the effect of creatine on cognition?"
+      },
+      "name": "get_subs",
+      "parent": 1,
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "question": "What is the effect of creatine on cognition?"
+      },
+      "name": "ask_subquestions",
+      "parent": 2,
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Decompose the following question into 2-5 subquestions that would help you answer the question. Make the questions stand alone, so that they can be answered without the context of the original question.\n\nQuestion: \"",
+            {
+              "formatted": "What is the effect of creatine on cognition?",
+              "source": "question",
+              "value": "What is the effect of creatine on cognition?"
+            },
+            "\"\nSubquestions:\n-"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 3,
+      "shortArgs": [
+        "Decompose the following question in...",
+        "\"\nSubquestions:\n-"
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": "Thousand hair beautiful few head.",
+      "shortResult": [
+        "Thousand hair beautiful few head."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [
+        "Thousand hair beautiful few head."
+      ],
+      "shortResult": [
+        "Thousand hair beautiful few head."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "question": "Thousand hair beautiful few head.",
+        "subs": []
+      },
+      "name": "answer",
+      "parent": 2,
+      "shortArgs": [
+        "Thousand hair beautiful few head."
+      ]
+    }
+  },
+  {
+    "6": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Answer the following question, using the background information above where helpful:\n\nQuestion: \"",
+            {
+              "formatted": "Thousand hair beautiful few head.",
+              "source": "question",
+              "value": "Thousand hair beautiful few head."
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 5,
+      "shortArgs": [
+        "Answer the following question, usin...",
+        "\"\nAnswer: \""
+      ]
+    }
+  },
+  {
+    "6": {
+      "result": "Again wide prevent.",
+      "shortResult": [
+        "Again wide prevent."
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": "Again wide prevent.",
+      "shortResult": [
+        "Again wide prevent."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [
+        [
+          "Thousand hair beautiful few head.",
+          "Again wide prevent."
+        ]
+      ],
+      "shortResult": [
+        "Thousand hair beautiful few head.",
+        "Again wide prevent."
+      ]
+    }
+  },
+  {
+    "7": {
+      "args": {
+        "question": "What is the effect of creatine on cognition?",
+        "subs": [
+          [
+            "Thousand hair beautiful few head.",
+            "Again wide prevent."
+          ]
+        ]
+      },
+      "name": "answer",
+      "parent": 1,
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
+    }
+  },
+  {
+    "8": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            {
+              "formatted": "Here is relevant background information:\n\nQ: Thousand hair beautiful few head.\nA: Again wide prevent.\n\n",
+              "source": "background_text",
+              "value": {
+                "__fstring__": [
+                  "Here is relevant background information:\n\n",
+                  {
+                    "formatted": "Q: Thousand hair beautiful few head.\nA: Again wide prevent.",
+                    "source": "subs_text",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "Q: Thousand hair beautiful few head.\nA: Again wide prevent.",
+                          "source": "list((F(f\"Q: {q}\\nA: {a}\") for (q, a) in subs))[0]",
+                          "value": {
+                            "__fstring__": [
+                              "Q: ",
+                              {
+                                "formatted": "Thousand hair beautiful few head.",
+                                "source": "q",
+                                "value": "Thousand hair beautiful few head."
+                              },
+                              "\nA: ",
+                              {
+                                "formatted": "Again wide prevent.",
+                                "source": "a",
+                                "value": "Again wide prevent."
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "\n\n"
+                ]
+              }
+            },
+            "Answer the following question, using the background information above where helpful:\n\nQuestion: \"",
+            {
+              "formatted": "What is the effect of creatine on cognition?",
+              "source": "question",
+              "value": "What is the effect of creatine on cognition?"
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 7,
+      "shortArgs": [
+        "background_text"
+      ]
+    }
+  },
+  {
+    "8": {
+      "result": "Recently note sell provide ok expect.",
+      "shortResult": [
+        "Recently note sell provide ok expec..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "result": "Recently note sell provide ok expect.",
+      "shortResult": [
+        "Recently note sell provide ok expec..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Recently note sell provide ok expect.",
+      "shortResult": [
+        "Recently note sell provide ok expec..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_amplification1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_amplification1].json
@@ -6,7 +6,9 @@
       },
       "name": "answer_by_amplification",
       "parent": 0,
-      "shortArgs": ["What is the effect of creatine on c..."]
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
     }
   },
   {
@@ -16,7 +18,9 @@
       },
       "name": "get_subs",
       "parent": 1,
-      "shortArgs": ["What is the effect of creatine on c..."]
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
     }
   },
   {
@@ -26,7 +30,9 @@
       },
       "name": "ask_subquestions",
       "parent": 2,
-      "shortArgs": ["What is the effect of creatine on c..."]
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
     }
   },
   {
@@ -54,19 +60,28 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": ["Decompose the following question in...", "\"\nSubquestions:\n-"]
+      "shortArgs": [
+        "Decompose the following question in...",
+        "\"\nSubquestions:\n-"
+      ]
     }
   },
   {
     "4": {
       "result": "Thousand hair beautiful few head.",
-      "shortResult": ["Thousand hair beautiful few head."]
+      "shortResult": [
+        "Thousand hair beautiful few head."
+      ]
     }
   },
   {
     "3": {
-      "result": ["Thousand hair beautiful few head."],
-      "shortResult": ["Thousand hair beautiful few head."]
+      "result": [
+        "Thousand hair beautiful few head."
+      ],
+      "shortResult": [
+        "Thousand hair beautiful few head."
+      ]
     }
   },
   {
@@ -77,7 +92,9 @@
       },
       "name": "answer",
       "parent": 2,
-      "shortArgs": ["Thousand hair beautiful few head."]
+      "shortArgs": [
+        "Thousand hair beautiful few head."
+      ]
     }
   },
   {
@@ -105,36 +122,58 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 5,
-      "shortArgs": ["Answer the following question, usin...", "\"\nAnswer: \""]
+      "shortArgs": [
+        "Answer the following question, usin...",
+        "\"\nAnswer: \""
+      ]
     }
   },
   {
     "6": {
       "result": "Again wide prevent.",
-      "shortResult": ["Again wide prevent."]
+      "shortResult": [
+        "Again wide prevent."
+      ]
     }
   },
   {
     "5": {
       "result": "Again wide prevent.",
-      "shortResult": ["Again wide prevent."]
+      "shortResult": [
+        "Again wide prevent."
+      ]
     }
   },
   {
     "2": {
-      "result": [["Thousand hair beautiful few head.", "Again wide prevent."]],
-      "shortResult": ["Thousand hair beautiful few head.", "Again wide prevent."]
+      "result": [
+        [
+          "Thousand hair beautiful few head.",
+          "Again wide prevent."
+        ]
+      ],
+      "shortResult": [
+        "Thousand hair beautiful few head.",
+        "Again wide prevent."
+      ]
     }
   },
   {
     "7": {
       "args": {
         "question": "What is the effect of creatine on cognition?",
-        "subs": [["Thousand hair beautiful few head.", "Again wide prevent."]]
+        "subs": [
+          [
+            "Thousand hair beautiful few head.",
+            "Again wide prevent."
+          ]
+        ]
       },
       "name": "answer",
       "parent": 1,
-      "shortArgs": ["What is the effect of creatine on c..."]
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
     }
   },
   {
@@ -200,25 +239,33 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 7,
-      "shortArgs": ["background_text"]
+      "shortArgs": [
+        "background_text"
+      ]
     }
   },
   {
     "8": {
       "result": "Recently note sell provide ok expect.",
-      "shortResult": ["Recently note sell provide ok expec..."]
+      "shortResult": [
+        "Recently note sell provide ok expec..."
+      ]
     }
   },
   {
     "7": {
       "result": "Recently note sell provide ok expect.",
-      "shortResult": ["Recently note sell provide ok expec..."]
+      "shortResult": [
+        "Recently note sell provide ok expec..."
+      ]
     }
   },
   {
     "1": {
       "result": "Recently note sell provide ok expect.",
-      "shortResult": ["Recently note sell provide ok expec..."]
+      "shortResult": [
+        "Recently note sell provide ok expec..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_amplification1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_amplification1].json
@@ -6,9 +6,7 @@
       },
       "name": "answer_by_amplification",
       "parent": 0,
-      "shortArgs": [
-        "What is the effect of creatine on c..."
-      ]
+      "shortArgs": ["What is the effect of creatine on c..."]
     }
   },
   {
@@ -18,9 +16,7 @@
       },
       "name": "get_subs",
       "parent": 1,
-      "shortArgs": [
-        "What is the effect of creatine on c..."
-      ]
+      "shortArgs": ["What is the effect of creatine on c..."]
     }
   },
   {
@@ -30,9 +26,7 @@
       },
       "name": "ask_subquestions",
       "parent": 2,
-      "shortArgs": [
-        "What is the effect of creatine on c..."
-      ]
+      "shortArgs": ["What is the effect of creatine on c..."]
     }
   },
   {
@@ -60,28 +54,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 3,
-      "shortArgs": [
-        "Decompose the following question in...",
-        "\"\nSubquestions:\n-"
-      ]
+      "shortArgs": ["Decompose the following question in...", "\"\nSubquestions:\n-"]
     }
   },
   {
     "4": {
       "result": "Thousand hair beautiful few head.",
-      "shortResult": [
-        "Thousand hair beautiful few head."
-      ]
+      "shortResult": ["Thousand hair beautiful few head."]
     }
   },
   {
     "3": {
-      "result": [
-        "Thousand hair beautiful few head."
-      ],
-      "shortResult": [
-        "Thousand hair beautiful few head."
-      ]
+      "result": ["Thousand hair beautiful few head."],
+      "shortResult": ["Thousand hair beautiful few head."]
     }
   },
   {
@@ -92,9 +77,7 @@
       },
       "name": "answer",
       "parent": 2,
-      "shortArgs": [
-        "Thousand hair beautiful few head."
-      ]
+      "shortArgs": ["Thousand hair beautiful few head."]
     }
   },
   {
@@ -122,58 +105,36 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 5,
-      "shortArgs": [
-        "Answer the following question, usin...",
-        "\"\nAnswer: \""
-      ]
+      "shortArgs": ["Answer the following question, usin...", "\"\nAnswer: \""]
     }
   },
   {
     "6": {
       "result": "Again wide prevent.",
-      "shortResult": [
-        "Again wide prevent."
-      ]
+      "shortResult": ["Again wide prevent."]
     }
   },
   {
     "5": {
       "result": "Again wide prevent.",
-      "shortResult": [
-        "Again wide prevent."
-      ]
+      "shortResult": ["Again wide prevent."]
     }
   },
   {
     "2": {
-      "result": [
-        [
-          "Thousand hair beautiful few head.",
-          "Again wide prevent."
-        ]
-      ],
-      "shortResult": [
-        "Thousand hair beautiful few head.",
-        "Again wide prevent."
-      ]
+      "result": [["Thousand hair beautiful few head.", "Again wide prevent."]],
+      "shortResult": ["Thousand hair beautiful few head.", "Again wide prevent."]
     }
   },
   {
     "7": {
       "args": {
         "question": "What is the effect of creatine on cognition?",
-        "subs": [
-          [
-            "Thousand hair beautiful few head.",
-            "Again wide prevent."
-          ]
-        ]
+        "subs": [["Thousand hair beautiful few head.", "Again wide prevent."]]
       },
       "name": "answer",
       "parent": 1,
-      "shortArgs": [
-        "What is the effect of creatine on c..."
-      ]
+      "shortArgs": ["What is the effect of creatine on c..."]
     }
   },
   {
@@ -239,33 +200,25 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 7,
-      "shortArgs": [
-        "background_text"
-      ]
+      "shortArgs": ["background_text"]
     }
   },
   {
     "8": {
       "result": "Recently note sell provide ok expect.",
-      "shortResult": [
-        "Recently note sell provide ok expec..."
-      ]
+      "shortResult": ["Recently note sell provide ok expec..."]
     }
   },
   {
     "7": {
       "result": "Recently note sell provide ok expect.",
-      "shortResult": [
-        "Recently note sell provide ok expec..."
-      ]
+      "shortResult": ["Recently note sell provide ok expec..."]
     }
   },
   {
     "1": {
       "result": "Recently note sell provide ok expect.",
-      "shortResult": [
-        "Recently note sell provide ok expec..."
-      ]
+      "shortResult": ["Recently note sell provide ok expec..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_amplification2].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_amplification2].json
@@ -6,9 +6,7 @@
       },
       "name": "answer_by_amplification",
       "parent": 0,
-      "shortArgs": [
-        "What is the effect of creatine on c..."
-      ]
+      "shortArgs": ["What is the effect of creatine on c..."]
     }
   },
   {
@@ -18,9 +16,7 @@
       },
       "name": "ask_subquestions",
       "parent": 1,
-      "shortArgs": [
-        "What is the effect of creatine on c..."
-      ]
+      "shortArgs": ["What is the effect of creatine on c..."]
     }
   },
   {
@@ -48,28 +44,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": [
-        "Decompose the following question in...",
-        "\"\nSubquestions:\n-"
-      ]
+      "shortArgs": ["Decompose the following question in...", "\"\nSubquestions:\n-"]
     }
   },
   {
     "3": {
       "result": "Four less avoid office pay family them.",
-      "shortResult": [
-        "Four less avoid office pay family t..."
-      ]
+      "shortResult": ["Four less avoid office pay family t..."]
     }
   },
   {
     "2": {
-      "result": [
-        "Four less avoid office pay family them."
-      ],
-      "shortResult": [
-        "Four less avoid office pay family t..."
-      ]
+      "result": ["Four less avoid office pay family them."],
+      "shortResult": ["Four less avoid office pay family t..."]
     }
   },
   {
@@ -79,9 +66,7 @@
       },
       "name": "answer",
       "parent": 1,
-      "shortArgs": [
-        "Four less avoid office pay family t..."
-      ]
+      "shortArgs": ["Four less avoid office pay family t..."]
     }
   },
   {
@@ -109,35 +94,25 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 4,
-      "shortArgs": [
-        "Answer the following question:\n\nQue...",
-        "\"\nAnswer: \""
-      ]
+      "shortArgs": ["Answer the following question:\n\nQue...", "\"\nAnswer: \""]
     }
   },
   {
     "5": {
       "result": "We tree section support individual.",
-      "shortResult": [
-        "We tree section support individual."
-      ]
+      "shortResult": ["We tree section support individual."]
     }
   },
   {
     "4": {
       "result": "We tree section support individual.",
-      "shortResult": [
-        "We tree section support individual."
-      ]
+      "shortResult": ["We tree section support individual."]
     }
   },
   {
     "1": {
       "result": [
-        [
-          "Four less avoid office pay family them.",
-          "We tree section support individual."
-        ]
+        ["Four less avoid office pay family them.", "We tree section support individual."]
       ],
       "shortResult": [
         "Four less avoid office pay family t...",

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_amplification2].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_amplification2].json
@@ -6,7 +6,9 @@
       },
       "name": "answer_by_amplification",
       "parent": 0,
-      "shortArgs": ["What is the effect of creatine on c..."]
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
     }
   },
   {
@@ -16,7 +18,9 @@
       },
       "name": "ask_subquestions",
       "parent": 1,
-      "shortArgs": ["What is the effect of creatine on c..."]
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
     }
   },
   {
@@ -44,19 +48,28 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 2,
-      "shortArgs": ["Decompose the following question in...", "\"\nSubquestions:\n-"]
+      "shortArgs": [
+        "Decompose the following question in...",
+        "\"\nSubquestions:\n-"
+      ]
     }
   },
   {
     "3": {
       "result": "Four less avoid office pay family them.",
-      "shortResult": ["Four less avoid office pay family t..."]
+      "shortResult": [
+        "Four less avoid office pay family t..."
+      ]
     }
   },
   {
     "2": {
-      "result": ["Four less avoid office pay family them."],
-      "shortResult": ["Four less avoid office pay family t..."]
+      "result": [
+        "Four less avoid office pay family them."
+      ],
+      "shortResult": [
+        "Four less avoid office pay family t..."
+      ]
     }
   },
   {
@@ -66,7 +79,9 @@
       },
       "name": "answer",
       "parent": 1,
-      "shortArgs": ["Four less avoid office pay family t..."]
+      "shortArgs": [
+        "Four less avoid office pay family t..."
+      ]
     }
   },
   {
@@ -94,25 +109,35 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 4,
-      "shortArgs": ["Answer the following question:\n\nQue...", "\"\nAnswer: \""]
+      "shortArgs": [
+        "Answer the following question:\n\nQue...",
+        "\"\nAnswer: \""
+      ]
     }
   },
   {
     "5": {
       "result": "We tree section support individual.",
-      "shortResult": ["We tree section support individual."]
+      "shortResult": [
+        "We tree section support individual."
+      ]
     }
   },
   {
     "4": {
       "result": "We tree section support individual.",
-      "shortResult": ["We tree section support individual."]
+      "shortResult": [
+        "We tree section support individual."
+      ]
     }
   },
   {
     "1": {
       "result": [
-        ["Four less avoid office pay family them.", "We tree section support individual."]
+        [
+          "Four less avoid office pay family them.",
+          "We tree section support individual."
+        ]
       ],
       "shortResult": [
         "Four less avoid office pay family t...",

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_amplification2].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_amplification2].json
@@ -1,0 +1,148 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "What is the effect of creatine on cognition?"
+      },
+      "name": "answer_by_amplification",
+      "parent": 0,
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "question": "What is the effect of creatine on cognition?"
+      },
+      "name": "ask_subquestions",
+      "parent": 1,
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Decompose the following question into 2-5 subquestions that would help you answer the question. Make the questions stand alone, so that they can be answered without the context of the original question.\n\nQuestion: \"",
+            {
+              "formatted": "What is the effect of creatine on cognition?",
+              "source": "question",
+              "value": "What is the effect of creatine on cognition?"
+            },
+            "\"\nSubquestions:\n-"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 2,
+      "shortArgs": [
+        "Decompose the following question in...",
+        "\"\nSubquestions:\n-"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": "Four less avoid office pay family them.",
+      "shortResult": [
+        "Four less avoid office pay family t..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [
+        "Four less avoid office pay family them."
+      ],
+      "shortResult": [
+        "Four less avoid office pay family t..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "question": "Four less avoid office pay family them."
+      },
+      "name": "answer",
+      "parent": 1,
+      "shortArgs": [
+        "Four less avoid office pay family t..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Answer the following question:\n\nQuestion: \"",
+            {
+              "formatted": "Four less avoid office pay family them.",
+              "source": "question",
+              "value": "Four less avoid office pay family them."
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 4,
+      "shortArgs": [
+        "Answer the following question:\n\nQue...",
+        "\"\nAnswer: \""
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": "We tree section support individual.",
+      "shortResult": [
+        "We tree section support individual."
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": "We tree section support individual.",
+      "shortResult": [
+        "We tree section support individual."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": [
+        [
+          "Four less avoid office pay family them.",
+          "We tree section support individual."
+        ]
+      ],
+      "shortResult": [
+        "Four less avoid office pay family t...",
+        "We tree section support individual."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_computation0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_computation0].json
@@ -1,0 +1,134 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "Foot space school movement trouble record."
+      },
+      "name": "answer_by_computation",
+      "parent": 0,
+      "shortArgs": [
+        "Foot space school movement trouble..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "question": "Foot space school movement trouble record."
+      },
+      "name": "choose_computation",
+      "parent": 1,
+      "shortArgs": [
+        "Foot space school movement trouble..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "You've been asked to answer the question \"",
+            {
+              "formatted": "Foot space school movement trouble record.",
+              "source": "question",
+              "value": "Foot space school movement trouble record."
+            },
+            "\".\n\nYou have access to a Python interpreter.\n\nEnter an expression that will help you answer the question.\n>>>"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 2,
+      "shortArgs": [
+        "You've been asked to answer the que...",
+        "\".\n\nYou have access to a Python int..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": "Oil price cup court information somebody its.",
+      "shortResult": [
+        "Oil price cup court information som..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Oil price cup court information somebody its.",
+      "shortResult": [
+        "Oil price cup court information som..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "A recording of a Python interpreter session:\n\n>>> ",
+            {
+              "formatted": "Oil price cup court information somebody its.",
+              "source": "expression",
+              "value": "Oil price cup court information somebody its."
+            },
+            ": ",
+            {
+              "formatted": "Error: invalid syntax (<string>, line 1)",
+              "source": "result",
+              "value": "Error: invalid syntax (<string>, line 1)"
+            },
+            "\n\nAnswer the following question, using the Python session if helpful:\n\nQuestion: \"",
+            {
+              "formatted": "Foot space school movement trouble record.",
+              "source": "question",
+              "value": "Foot space school movement trouble record."
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 1,
+      "shortArgs": [
+        "A recording of a Python interpreter...",
+        ": ",
+        "Answer the following question, us...",
+        "..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": "Forget hour child pay traditional region.",
+      "shortResult": [
+        "Forget hour child pay traditional r..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Forget hour child pay traditional region.",
+      "shortResult": [
+        "Forget hour child pay traditional r..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_computation0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_computation0].json
@@ -6,9 +6,7 @@
       },
       "name": "answer_by_computation",
       "parent": 0,
-      "shortArgs": [
-        "Foot space school movement trouble..."
-      ]
+      "shortArgs": ["Foot space school movement trouble..."]
     }
   },
   {
@@ -18,9 +16,7 @@
       },
       "name": "choose_computation",
       "parent": 1,
-      "shortArgs": [
-        "Foot space school movement trouble..."
-      ]
+      "shortArgs": ["Foot space school movement trouble..."]
     }
   },
   {
@@ -57,17 +53,13 @@
   {
     "3": {
       "result": "Oil price cup court information somebody its.",
-      "shortResult": [
-        "Oil price cup court information som..."
-      ]
+      "shortResult": ["Oil price cup court information som..."]
     }
   },
   {
     "2": {
       "result": "Oil price cup court information somebody its.",
-      "shortResult": [
-        "Oil price cup court information som..."
-      ]
+      "shortResult": ["Oil price cup court information som..."]
     }
   },
   {
@@ -118,17 +110,13 @@
   {
     "4": {
       "result": "Forget hour child pay traditional region.",
-      "shortResult": [
-        "Forget hour child pay traditional r..."
-      ]
+      "shortResult": ["Forget hour child pay traditional r..."]
     }
   },
   {
     "1": {
       "result": "Forget hour child pay traditional region.",
-      "shortResult": [
-        "Forget hour child pay traditional r..."
-      ]
+      "shortResult": ["Forget hour child pay traditional r..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_computation0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_computation0].json
@@ -6,7 +6,9 @@
       },
       "name": "answer_by_computation",
       "parent": 0,
-      "shortArgs": ["Foot space school movement trouble..."]
+      "shortArgs": [
+        "Foot space school movement trouble..."
+      ]
     }
   },
   {
@@ -16,7 +18,9 @@
       },
       "name": "choose_computation",
       "parent": 1,
-      "shortArgs": ["Foot space school movement trouble..."]
+      "shortArgs": [
+        "Foot space school movement trouble..."
+      ]
     }
   },
   {
@@ -53,13 +57,17 @@
   {
     "3": {
       "result": "Oil price cup court information somebody its.",
-      "shortResult": ["Oil price cup court information som..."]
+      "shortResult": [
+        "Oil price cup court information som..."
+      ]
     }
   },
   {
     "2": {
       "result": "Oil price cup court information somebody its.",
-      "shortResult": ["Oil price cup court information som..."]
+      "shortResult": [
+        "Oil price cup court information som..."
+      ]
     }
   },
   {
@@ -110,13 +118,17 @@
   {
     "4": {
       "result": "Forget hour child pay traditional region.",
-      "shortResult": ["Forget hour child pay traditional r..."]
+      "shortResult": [
+        "Forget hour child pay traditional r..."
+      ]
     }
   },
   {
     "1": {
       "result": "Forget hour child pay traditional region.",
-      "shortResult": ["Forget hour child pay traditional r..."]
+      "shortResult": [
+        "Forget hour child pay traditional r..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_computation1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_computation1].json
@@ -6,17 +6,13 @@
       },
       "name": "answer_by_computation",
       "parent": 0,
-      "shortArgs": [
-        "Despite and century best green poor..."
-      ]
+      "shortArgs": ["Despite and century best green poor..."]
     }
   },
   {
     "1": {
       "result": "Error: invalid syntax (<string>, line 1)",
-      "shortResult": [
-        "Error: invalid syntax (<string>, li..."
-      ]
+      "shortResult": ["Error: invalid syntax (<string>, li..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_computation1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_computation1].json
@@ -6,13 +6,17 @@
       },
       "name": "answer_by_computation",
       "parent": 0,
-      "shortArgs": ["Despite and century best green poor..."]
+      "shortArgs": [
+        "Despite and century best green poor..."
+      ]
     }
   },
   {
     "1": {
       "result": "Error: invalid syntax (<string>, line 1)",
-      "shortResult": ["Error: invalid syntax (<string>, li..."]
+      "shortResult": [
+        "Error: invalid syntax (<string>, li..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_computation1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_computation1].json
@@ -1,0 +1,22 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "Despite and century best green poor senior add."
+      },
+      "name": "answer_by_computation",
+      "parent": 0,
+      "shortArgs": [
+        "Despite and century best green poor..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Error: invalid syntax (<string>, line 1)",
+      "shortResult": [
+        "Error: invalid syntax (<string>, li..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch0].json
@@ -1,0 +1,182 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "How many people live in Germany?"
+      },
+      "name": "answer_by_dispatch",
+      "parent": 0,
+      "shortArgs": [
+        "How many people live in Germany?"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "choices": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "You want to answer the question \"",
+            {
+              "formatted": "How many people live in Germany?",
+              "source": "question",
+              "value": "How many people live in Germany?"
+            },
+            "\".\n\nYou have the following options:\n\n",
+            {
+              "formatted": "1. Run a web search using Google. This is helpful if the question depends on obscure facts or current information, such as the weather or the latest news.\n2. Run a computation in Python. This is helpful if the question depends on calculation or other mechanical processes that you can specify in a short program.\n3. Write out the reasoning steps. This is helpful if the question involves logical deduction or evidence-based reasoning.",
+              "source": "action_types_str",
+              "value": {
+                "__fstring__": [
+                  {
+                    "formatted": "1. Run a web search using Google. This is helpful if the question depends on obscure facts or current information, such as the weather or the latest news.",
+                    "source": "([\n            F(f\"{i+1}. {action_type.description}\")\n            for i, action_type in enumerate(action_types)\n        ])[0]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "1",
+                          "source": "i+1",
+                          "value": 1
+                        },
+                        ". ",
+                        {
+                          "formatted": "Run a web search using Google. This is helpful if the question depends on obscure facts or current information, such as the weather or the latest news.",
+                          "source": "action_type.description",
+                          "value": "Run a web search using Google. This is helpful if the question depends on obscure facts or current information, such as the weather or the latest news."
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "2. Run a computation in Python. This is helpful if the question depends on calculation or other mechanical processes that you can specify in a short program.",
+                    "source": "([\n            F(f\"{i+1}. {action_type.description}\")\n            for i, action_type in enumerate(action_types)\n        ])[1]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "2",
+                          "source": "i+1",
+                          "value": 2
+                        },
+                        ". ",
+                        {
+                          "formatted": "Run a computation in Python. This is helpful if the question depends on calculation or other mechanical processes that you can specify in a short program.",
+                          "source": "action_type.description",
+                          "value": "Run a computation in Python. This is helpful if the question depends on calculation or other mechanical processes that you can specify in a short program."
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "3. Write out the reasoning steps. This is helpful if the question involves logical deduction or evidence-based reasoning.",
+                    "source": "([\n            F(f\"{i+1}. {action_type.description}\")\n            for i, action_type in enumerate(action_types)\n        ])[2]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "3",
+                          "source": "i+1",
+                          "value": 3
+                        },
+                        ". ",
+                        {
+                          "formatted": "Write out the reasoning steps. This is helpful if the question involves logical deduction or evidence-based reasoning.",
+                          "source": "action_type.description",
+                          "value": "Write out the reasoning steps. This is helpful if the question involves logical deduction or evidence-based reasoning."
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "\n\nQ: Which of these options do you want to use before you answer the question? Choose the option that will most help you give an accurate answer.\nA: I want to use option #"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 1,
+      "shortArgs": [
+        "You want to answer the question \"",
+        "\".\n\nYou have the following options:...",
+        "Q: Which of these options do you..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [
+        {
+          "1": 0.3460965933309753,
+          "2": 0.18704412463151252,
+          "3": 0.1647221659982181,
+          "4": 0.21709105340941567,
+          "5": 0.08504606262987853
+        },
+        null
+      ],
+      "shortResult": [
+        "0.3460965933309753"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": [
+        [
+          [
+            "1",
+            0.3460965933309753
+          ],
+          "Web search"
+        ],
+        [
+          [
+            "2",
+            0.18704412463151252
+          ],
+          "Computation"
+        ],
+        [
+          [
+            "3",
+            0.1647221659982181
+          ],
+          "Reasoning"
+        ]
+      ],
+      "shortResult": [
+        "1"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch0].json
@@ -6,21 +6,13 @@
       },
       "name": "answer_by_dispatch",
       "parent": 0,
-      "shortArgs": [
-        "How many people live in Germany?"
-      ]
+      "shortArgs": ["How many people live in Germany?"]
     }
   },
   {
     "2": {
       "args": {
-        "choices": [
-          "1",
-          "2",
-          "3",
-          "4",
-          "5"
-        ],
+        "choices": ["1", "2", "3", "4", "5"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -59,9 +51,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -87,9 +77,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -144,39 +132,17 @@
         },
         null
       ],
-      "shortResult": [
-        "0.3460965933309753"
-      ]
+      "shortResult": ["0.3460965933309753"]
     }
   },
   {
     "1": {
       "result": [
-        [
-          [
-            "1",
-            0.3460965933309753
-          ],
-          "Web search"
-        ],
-        [
-          [
-            "2",
-            0.18704412463151252
-          ],
-          "Computation"
-        ],
-        [
-          [
-            "3",
-            0.1647221659982181
-          ],
-          "Reasoning"
-        ]
+        [["1", 0.3460965933309753], "Web search"],
+        [["2", 0.18704412463151252], "Computation"],
+        [["3", 0.1647221659982181], "Reasoning"]
       ],
-      "shortResult": [
-        "1"
-      ]
+      "shortResult": ["1"]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch0].json
@@ -6,13 +6,21 @@
       },
       "name": "answer_by_dispatch",
       "parent": 0,
-      "shortArgs": ["How many people live in Germany?"]
+      "shortArgs": [
+        "How many people live in Germany?"
+      ]
     }
   },
   {
     "2": {
       "args": {
-        "choices": ["1", "2", "3", "4", "5"],
+        "choices": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -51,7 +59,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -77,7 +87,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -132,17 +144,39 @@
         },
         null
       ],
-      "shortResult": ["0.3460965933309753"]
+      "shortResult": [
+        "0.3460965933309753"
+      ]
     }
   },
   {
     "1": {
       "result": [
-        [["1", 0.3460965933309753], "Web search"],
-        [["2", 0.18704412463151252], "Computation"],
-        [["3", 0.1647221659982181], "Reasoning"]
+        [
+          [
+            "1",
+            0.3460965933309753
+          ],
+          "Web search"
+        ],
+        [
+          [
+            "2",
+            0.18704412463151252
+          ],
+          "Computation"
+        ],
+        [
+          [
+            "3",
+            0.1647221659982181
+          ],
+          "Reasoning"
+        ]
       ],
-      "shortResult": ["1"]
+      "shortResult": [
+        "1"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch1].json
@@ -6,7 +6,9 @@
       },
       "name": "answer_by_dispatch",
       "parent": 0,
-      "shortArgs": ["How many people live in Germany?"]
+      "shortArgs": [
+        "How many people live in Germany?"
+      ]
     }
   },
   {
@@ -16,13 +18,21 @@
       },
       "name": "select_action",
       "parent": 1,
-      "shortArgs": ["How many people live in Germany?"]
+      "shortArgs": [
+        "How many people live in Germany?"
+      ]
     }
   },
   {
     "3": {
       "args": {
-        "choices": ["1", "2", "3", "4", "5"],
+        "choices": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -61,7 +71,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -87,7 +99,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -142,7 +156,9 @@
         },
         null
       ],
-      "shortResult": ["0.19152525923958227"]
+      "shortResult": [
+        "0.19152525923958227"
+      ]
     }
   },
   {
@@ -155,7 +171,9 @@
           "name": "answer_by_computation"
         }
       },
-      "shortResult": ["Computation"]
+      "shortResult": [
+        "Computation"
+      ]
     }
   },
   {
@@ -165,7 +183,9 @@
       },
       "name": "answer_by_computation",
       "parent": 1,
-      "shortArgs": ["How many people live in Germany?"]
+      "shortArgs": [
+        "How many people live in Germany?"
+      ]
     }
   },
   {
@@ -175,7 +195,9 @@
       },
       "name": "choose_computation",
       "parent": 4,
-      "shortArgs": ["How many people live in Germany?"]
+      "shortArgs": [
+        "How many people live in Germany?"
+      ]
     }
   },
   {
@@ -212,13 +234,17 @@
   {
     "6": {
       "result": "Whether similar sort environment remember available technology.",
-      "shortResult": ["Whether similar sort environment re..."]
+      "shortResult": [
+        "Whether similar sort environment re..."
+      ]
     }
   },
   {
     "5": {
       "result": "Whether similar sort environment remember available technology.",
-      "shortResult": ["Whether similar sort environment re..."]
+      "shortResult": [
+        "Whether similar sort environment re..."
+      ]
     }
   },
   {
@@ -269,19 +295,25 @@
   {
     "7": {
       "result": "Friend detail alone less note.",
-      "shortResult": ["Friend detail alone less note."]
+      "shortResult": [
+        "Friend detail alone less note."
+      ]
     }
   },
   {
     "4": {
       "result": "Friend detail alone less note.",
-      "shortResult": ["Friend detail alone less note."]
+      "shortResult": [
+        "Friend detail alone less note."
+      ]
     }
   },
   {
     "1": {
       "result": "Friend detail alone less note.",
-      "shortResult": ["Friend detail alone less note."]
+      "shortResult": [
+        "Friend detail alone less note."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch1].json
@@ -6,9 +6,7 @@
       },
       "name": "answer_by_dispatch",
       "parent": 0,
-      "shortArgs": [
-        "How many people live in Germany?"
-      ]
+      "shortArgs": ["How many people live in Germany?"]
     }
   },
   {
@@ -18,21 +16,13 @@
       },
       "name": "select_action",
       "parent": 1,
-      "shortArgs": [
-        "How many people live in Germany?"
-      ]
+      "shortArgs": ["How many people live in Germany?"]
     }
   },
   {
     "3": {
       "args": {
-        "choices": [
-          "1",
-          "2",
-          "3",
-          "4",
-          "5"
-        ],
+        "choices": ["1", "2", "3", "4", "5"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -71,9 +61,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -99,9 +87,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -156,9 +142,7 @@
         },
         null
       ],
-      "shortResult": [
-        "0.19152525923958227"
-      ]
+      "shortResult": ["0.19152525923958227"]
     }
   },
   {
@@ -171,9 +155,7 @@
           "name": "answer_by_computation"
         }
       },
-      "shortResult": [
-        "Computation"
-      ]
+      "shortResult": ["Computation"]
     }
   },
   {
@@ -183,9 +165,7 @@
       },
       "name": "answer_by_computation",
       "parent": 1,
-      "shortArgs": [
-        "How many people live in Germany?"
-      ]
+      "shortArgs": ["How many people live in Germany?"]
     }
   },
   {
@@ -195,9 +175,7 @@
       },
       "name": "choose_computation",
       "parent": 4,
-      "shortArgs": [
-        "How many people live in Germany?"
-      ]
+      "shortArgs": ["How many people live in Germany?"]
     }
   },
   {
@@ -234,17 +212,13 @@
   {
     "6": {
       "result": "Whether similar sort environment remember available technology.",
-      "shortResult": [
-        "Whether similar sort environment re..."
-      ]
+      "shortResult": ["Whether similar sort environment re..."]
     }
   },
   {
     "5": {
       "result": "Whether similar sort environment remember available technology.",
-      "shortResult": [
-        "Whether similar sort environment re..."
-      ]
+      "shortResult": ["Whether similar sort environment re..."]
     }
   },
   {
@@ -295,25 +269,19 @@
   {
     "7": {
       "result": "Friend detail alone less note.",
-      "shortResult": [
-        "Friend detail alone less note."
-      ]
+      "shortResult": ["Friend detail alone less note."]
     }
   },
   {
     "4": {
       "result": "Friend detail alone less note.",
-      "shortResult": [
-        "Friend detail alone less note."
-      ]
+      "shortResult": ["Friend detail alone less note."]
     }
   },
   {
     "1": {
       "result": "Friend detail alone less note.",
-      "shortResult": [
-        "Friend detail alone less note."
-      ]
+      "shortResult": ["Friend detail alone less note."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_dispatch1].json
@@ -1,0 +1,319 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "How many people live in Germany?"
+      },
+      "name": "answer_by_dispatch",
+      "parent": 0,
+      "shortArgs": [
+        "How many people live in Germany?"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "question": "How many people live in Germany?"
+      },
+      "name": "select_action",
+      "parent": 1,
+      "shortArgs": [
+        "How many people live in Germany?"
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "choices": [
+          "1",
+          "2",
+          "3",
+          "4",
+          "5"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "You want to answer the question \"",
+            {
+              "formatted": "How many people live in Germany?",
+              "source": "question",
+              "value": "How many people live in Germany?"
+            },
+            "\".\n\nYou have the following options:\n\n",
+            {
+              "formatted": "1. Run a web search using Google. This is helpful if the question depends on obscure facts or current information, such as the weather or the latest news.\n2. Run a computation in Python. This is helpful if the question depends on calculation or other mechanical processes that you can specify in a short program.\n3. Write out the reasoning steps. This is helpful if the question involves logical deduction or evidence-based reasoning.",
+              "source": "action_types_str",
+              "value": {
+                "__fstring__": [
+                  {
+                    "formatted": "1. Run a web search using Google. This is helpful if the question depends on obscure facts or current information, such as the weather or the latest news.",
+                    "source": "([\n            F(f\"{i+1}. {action_type.description}\")\n            for i, action_type in enumerate(action_types)\n        ])[0]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "1",
+                          "source": "i+1",
+                          "value": 1
+                        },
+                        ". ",
+                        {
+                          "formatted": "Run a web search using Google. This is helpful if the question depends on obscure facts or current information, such as the weather or the latest news.",
+                          "source": "action_type.description",
+                          "value": "Run a web search using Google. This is helpful if the question depends on obscure facts or current information, such as the weather or the latest news."
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "2. Run a computation in Python. This is helpful if the question depends on calculation or other mechanical processes that you can specify in a short program.",
+                    "source": "([\n            F(f\"{i+1}. {action_type.description}\")\n            for i, action_type in enumerate(action_types)\n        ])[1]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "2",
+                          "source": "i+1",
+                          "value": 2
+                        },
+                        ". ",
+                        {
+                          "formatted": "Run a computation in Python. This is helpful if the question depends on calculation or other mechanical processes that you can specify in a short program.",
+                          "source": "action_type.description",
+                          "value": "Run a computation in Python. This is helpful if the question depends on calculation or other mechanical processes that you can specify in a short program."
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "3. Write out the reasoning steps. This is helpful if the question involves logical deduction or evidence-based reasoning.",
+                    "source": "([\n            F(f\"{i+1}. {action_type.description}\")\n            for i, action_type in enumerate(action_types)\n        ])[2]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "3",
+                          "source": "i+1",
+                          "value": 3
+                        },
+                        ". ",
+                        {
+                          "formatted": "Write out the reasoning steps. This is helpful if the question involves logical deduction or evidence-based reasoning.",
+                          "source": "action_type.description",
+                          "value": "Write out the reasoning steps. This is helpful if the question involves logical deduction or evidence-based reasoning."
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "\n\nQ: Which of these options do you want to use before you answer the question? Choose the option that will most help you give an accurate answer.\nA: I want to use option #"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 2,
+      "shortArgs": [
+        "You want to answer the question \"",
+        "\".\n\nYou have the following options:...",
+        "Q: Which of these options do you..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [
+        {
+          "1": 0.19152525923958227,
+          "2": 0.27693897437582116,
+          "3": 0.2229897674687923,
+          "4": 0.23153952039570347,
+          "5": 0.07700647852010072
+        },
+        null
+      ],
+      "shortResult": [
+        "0.19152525923958227"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": {
+        "description": "Run a computation in Python. This is helpful if the question depends on calculation or other mechanical processes that you can specify in a short program.",
+        "name": "Computation",
+        "recipe": {
+          "class_name": "function",
+          "name": "answer_by_computation"
+        }
+      },
+      "shortResult": [
+        "Computation"
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "question": "How many people live in Germany?"
+      },
+      "name": "answer_by_computation",
+      "parent": 1,
+      "shortArgs": [
+        "How many people live in Germany?"
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "question": "How many people live in Germany?"
+      },
+      "name": "choose_computation",
+      "parent": 4,
+      "shortArgs": [
+        "How many people live in Germany?"
+      ]
+    }
+  },
+  {
+    "6": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "You've been asked to answer the question \"",
+            {
+              "formatted": "How many people live in Germany?",
+              "source": "question",
+              "value": "How many people live in Germany?"
+            },
+            "\".\n\nYou have access to a Python interpreter.\n\nEnter an expression that will help you answer the question.\n>>>"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 5,
+      "shortArgs": [
+        "You've been asked to answer the que...",
+        "\".\n\nYou have access to a Python int..."
+      ]
+    }
+  },
+  {
+    "6": {
+      "result": "Whether similar sort environment remember available technology.",
+      "shortResult": [
+        "Whether similar sort environment re..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": "Whether similar sort environment remember available technology.",
+      "shortResult": [
+        "Whether similar sort environment re..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "A recording of a Python interpreter session:\n\n>>> ",
+            {
+              "formatted": "Whether similar sort environment remember available technology.",
+              "source": "expression",
+              "value": "Whether similar sort environment remember available technology."
+            },
+            ": ",
+            {
+              "formatted": "Error: invalid syntax (<string>, line 1)",
+              "source": "result",
+              "value": "Error: invalid syntax (<string>, line 1)"
+            },
+            "\n\nAnswer the following question, using the Python session if helpful:\n\nQuestion: \"",
+            {
+              "formatted": "How many people live in Germany?",
+              "source": "question",
+              "value": "How many people live in Germany?"
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 4,
+      "shortArgs": [
+        "A recording of a Python interpreter...",
+        ": ",
+        "Answer the following question, us...",
+        "..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "result": "Friend detail alone less note.",
+      "shortResult": [
+        "Friend detail alone less note."
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": "Friend detail alone less note.",
+      "shortResult": [
+        "Friend detail alone less note."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Friend detail alone less note.",
+      "shortResult": [
+        "Friend detail alone less note."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_reasoning].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_reasoning].json
@@ -6,9 +6,7 @@
       },
       "name": "answer_by_reasoning",
       "parent": 0,
-      "shortArgs": [
-        "What would happen if the average te..."
-      ]
+      "shortArgs": ["What would happen if the average te..."]
     }
   },
   {
@@ -18,9 +16,7 @@
       },
       "name": "get_reasoning",
       "parent": 1,
-      "shortArgs": [
-        "What would happen if the average te..."
-      ]
+      "shortArgs": ["What would happen if the average te..."]
     }
   },
   {
@@ -57,17 +53,13 @@
   {
     "3": {
       "result": "Participant professional past measure.",
-      "shortResult": [
-        "Participant professional past measu..."
-      ]
+      "shortResult": ["Participant professional past measu..."]
     }
   },
   {
     "2": {
       "result": "Participant professional past measure.",
-      "shortResult": [
-        "Participant professional past measu..."
-      ]
+      "shortResult": ["Participant professional past measu..."]
     }
   },
   {
@@ -78,9 +70,7 @@
       },
       "name": "get_answer",
       "parent": 1,
-      "shortArgs": [
-        "What would happen if the average te..."
-      ]
+      "shortArgs": ["What would happen if the average te..."]
     }
   },
   {
@@ -124,25 +114,19 @@
   {
     "5": {
       "result": "Still fear public better process so.",
-      "shortResult": [
-        "Still fear public better process so..."
-      ]
+      "shortResult": ["Still fear public better process so..."]
     }
   },
   {
     "4": {
       "result": "Still fear public better process so.",
-      "shortResult": [
-        "Still fear public better process so..."
-      ]
+      "shortResult": ["Still fear public better process so..."]
     }
   },
   {
     "1": {
       "result": "Still fear public better process so.",
-      "shortResult": [
-        "Still fear public better process so..."
-      ]
+      "shortResult": ["Still fear public better process so..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_reasoning].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_reasoning].json
@@ -1,0 +1,148 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "What would happen if the average temperature in Northern California went up by 5 degrees Fahrenheit?"
+      },
+      "name": "answer_by_reasoning",
+      "parent": 0,
+      "shortArgs": [
+        "What would happen if the average te..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "question": "What would happen if the average temperature in Northern California went up by 5 degrees Fahrenheit?"
+      },
+      "name": "get_reasoning",
+      "parent": 1,
+      "shortArgs": [
+        "What would happen if the average te..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Answer the following question:\n\nQuestion: \"",
+            {
+              "formatted": "What would happen if the average temperature in Northern California went up by 5 degrees Fahrenheit?",
+              "source": "question",
+              "value": "What would happen if the average temperature in Northern California went up by 5 degrees Fahrenheit?"
+            },
+            "\"\nAnswer: \"Let's think step by step."
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 2,
+      "shortArgs": [
+        "Answer the following question:\n\nQue...",
+        "\"\nAnswer: \"Let's think step by step..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": "Participant professional past measure.",
+      "shortResult": [
+        "Participant professional past measu..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Participant professional past measure.",
+      "shortResult": [
+        "Participant professional past measu..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "question": "What would happen if the average temperature in Northern California went up by 5 degrees Fahrenheit?",
+        "reasoning": "Participant professional past measure."
+      },
+      "name": "get_answer",
+      "parent": 1,
+      "shortArgs": [
+        "What would happen if the average te..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Answer the following question using the reasoning shown below:\n\nQuestion: \"",
+            {
+              "formatted": "What would happen if the average temperature in Northern California went up by 5 degrees Fahrenheit?",
+              "source": "question",
+              "value": "What would happen if the average temperature in Northern California went up by 5 degrees Fahrenheit?"
+            },
+            "\"\nReasoning: \"",
+            {
+              "formatted": "Participant professional past measure.",
+              "source": "reasoning",
+              "value": "Participant professional past measure."
+            },
+            "\"\nShort answer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 4,
+      "shortArgs": [
+        "Answer the following question using...",
+        "\"\nReasoning: \"",
+        "\"\nShort answer: \""
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": "Still fear public better process so.",
+      "shortResult": [
+        "Still fear public better process so..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": "Still fear public better process so.",
+      "shortResult": [
+        "Still fear public better process so..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Still fear public better process so.",
+      "shortResult": [
+        "Still fear public better process so..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_reasoning].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_reasoning].json
@@ -6,7 +6,9 @@
       },
       "name": "answer_by_reasoning",
       "parent": 0,
-      "shortArgs": ["What would happen if the average te..."]
+      "shortArgs": [
+        "What would happen if the average te..."
+      ]
     }
   },
   {
@@ -16,7 +18,9 @@
       },
       "name": "get_reasoning",
       "parent": 1,
-      "shortArgs": ["What would happen if the average te..."]
+      "shortArgs": [
+        "What would happen if the average te..."
+      ]
     }
   },
   {
@@ -53,13 +57,17 @@
   {
     "3": {
       "result": "Participant professional past measure.",
-      "shortResult": ["Participant professional past measu..."]
+      "shortResult": [
+        "Participant professional past measu..."
+      ]
     }
   },
   {
     "2": {
       "result": "Participant professional past measure.",
-      "shortResult": ["Participant professional past measu..."]
+      "shortResult": [
+        "Participant professional past measu..."
+      ]
     }
   },
   {
@@ -70,7 +78,9 @@
       },
       "name": "get_answer",
       "parent": 1,
-      "shortArgs": ["What would happen if the average te..."]
+      "shortArgs": [
+        "What would happen if the average te..."
+      ]
     }
   },
   {
@@ -114,19 +124,25 @@
   {
     "5": {
       "result": "Still fear public better process so.",
-      "shortResult": ["Still fear public better process so..."]
+      "shortResult": [
+        "Still fear public better process so..."
+      ]
     }
   },
   {
     "4": {
       "result": "Still fear public better process so.",
-      "shortResult": ["Still fear public better process so..."]
+      "shortResult": [
+        "Still fear public better process so..."
+      ]
     }
   },
   {
     "1": {
       "result": "Still fear public better process so.",
-      "shortResult": ["Still fear public better process so..."]
+      "shortResult": [
+        "Still fear public better process so..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_search0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_search0].json
@@ -6,7 +6,9 @@
       },
       "name": "answer_by_search",
       "parent": 0,
-      "shortArgs": ["Who is the president of the United..."]
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
     }
   },
   {
@@ -16,7 +18,9 @@
       },
       "name": "choose_query",
       "parent": 1,
-      "shortArgs": ["Who is the president of the United..."]
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
     }
   },
   {
@@ -53,13 +57,17 @@
   {
     "3": {
       "result": "Push cold school animal property week.",
-      "shortResult": ["Push cold school animal property we..."]
+      "shortResult": [
+        "Push cold school animal property we..."
+      ]
     }
   },
   {
     "2": {
       "result": "Push cold school animal property week.",
-      "shortResult": ["Push cold school animal property we..."]
+      "shortResult": [
+        "Push cold school animal property we..."
+      ]
     }
   },
   {
@@ -69,7 +77,9 @@
       },
       "name": "search",
       "parent": 1,
-      "shortArgs": ["Push cold school animal property we..."]
+      "shortArgs": [
+        "Push cold school animal property we..."
+      ]
     }
   },
   {
@@ -77,7 +87,9 @@
       "result": {
         "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
       },
-      "shortResult": ["Invalid API key. Your API key shoul..."]
+      "shortResult": [
+        "Invalid API key. Your API key shoul..."
+      ]
     }
   },
   {
@@ -128,13 +140,17 @@
   {
     "5": {
       "result": "Road prove personal expect agreement billion such.",
-      "shortResult": ["Road prove personal expect agreemen..."]
+      "shortResult": [
+        "Road prove personal expect agreemen..."
+      ]
     }
   },
   {
     "1": {
       "result": "Road prove personal expect agreement billion such.",
-      "shortResult": ["Road prove personal expect agreemen..."]
+      "shortResult": [
+        "Road prove personal expect agreemen..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_search0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_search0].json
@@ -6,9 +6,7 @@
       },
       "name": "answer_by_search",
       "parent": 0,
-      "shortArgs": [
-        "Who is the president of the United..."
-      ]
+      "shortArgs": ["Who is the president of the United..."]
     }
   },
   {
@@ -18,9 +16,7 @@
       },
       "name": "choose_query",
       "parent": 1,
-      "shortArgs": [
-        "Who is the president of the United..."
-      ]
+      "shortArgs": ["Who is the president of the United..."]
     }
   },
   {
@@ -57,17 +53,13 @@
   {
     "3": {
       "result": "Push cold school animal property week.",
-      "shortResult": [
-        "Push cold school animal property we..."
-      ]
+      "shortResult": ["Push cold school animal property we..."]
     }
   },
   {
     "2": {
       "result": "Push cold school animal property week.",
-      "shortResult": [
-        "Push cold school animal property we..."
-      ]
+      "shortResult": ["Push cold school animal property we..."]
     }
   },
   {
@@ -77,9 +69,7 @@
       },
       "name": "search",
       "parent": 1,
-      "shortArgs": [
-        "Push cold school animal property we..."
-      ]
+      "shortArgs": ["Push cold school animal property we..."]
     }
   },
   {
@@ -87,9 +77,7 @@
       "result": {
         "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
       },
-      "shortResult": [
-        "Invalid API key. Your API key shoul..."
-      ]
+      "shortResult": ["Invalid API key. Your API key shoul..."]
     }
   },
   {
@@ -140,17 +128,13 @@
   {
     "5": {
       "result": "Road prove personal expect agreement billion such.",
-      "shortResult": [
-        "Road prove personal expect agreemen..."
-      ]
+      "shortResult": ["Road prove personal expect agreemen..."]
     }
   },
   {
     "1": {
       "result": "Road prove personal expect agreement billion such.",
-      "shortResult": [
-        "Road prove personal expect agreemen..."
-      ]
+      "shortResult": ["Road prove personal expect agreemen..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_search0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_search0].json
@@ -1,0 +1,156 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "Who is the president of the United States?"
+      },
+      "name": "answer_by_search",
+      "parent": 0,
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "question": "Who is the president of the United States?"
+      },
+      "name": "choose_query",
+      "parent": 1,
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "\nYou're trying to answer the question ",
+            {
+              "formatted": "Who is the president of the United States?",
+              "source": "question",
+              "value": "Who is the president of the United States?"
+            },
+            ". You get to type in a search query to Google, and then you'll be shown the results. What query do you want to search for?\n\nQuery: \"\n"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 2,
+      "shortArgs": [
+        "You're trying to answer the questi...",
+        ". You get to type in a search query..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": "Push cold school animal property week.",
+      "shortResult": [
+        "Push cold school animal property we..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Push cold school animal property week.",
+      "shortResult": [
+        "Push cold school animal property we..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "query": "Push cold school animal property week."
+      },
+      "name": "search",
+      "parent": 1,
+      "shortArgs": [
+        "Push cold school animal property we..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": {
+        "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
+      },
+      "shortResult": [
+        "Invalid API key. Your API key shoul..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Search results from Google for the query \"",
+            {
+              "formatted": "Push cold school animal property week.",
+              "source": "query",
+              "value": "Push cold school animal property week."
+            },
+            "\": \"",
+            {
+              "formatted": "No results found",
+              "source": "context",
+              "value": "No results found"
+            },
+            "\"\n\nAnswer the following question, using the search results if helpful:\n\nQuestion: \"",
+            {
+              "formatted": "Who is the president of the United States?",
+              "source": "question",
+              "value": "Who is the president of the United States?"
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 1,
+      "shortArgs": [
+        "Search results from Google for the...",
+        "\": \"",
+        "\"\n\nAnswer the following question, u...",
+        "..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": "Road prove personal expect agreement billion such.",
+      "shortResult": [
+        "Road prove personal expect agreemen..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Road prove personal expect agreement billion such.",
+      "shortResult": [
+        "Road prove personal expect agreemen..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_search1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_search1].json
@@ -1,0 +1,90 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "Who is the president of the United States?"
+      },
+      "name": "answer_by_search",
+      "parent": 0,
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "query": "Who is the president of the United States?"
+      },
+      "name": "search",
+      "parent": 1,
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": {
+        "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
+      },
+      "shortResult": [
+        "Invalid API key. Your API key shoul..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "default": "",
+        "max_tokens": 100,
+        "prompt": {
+          "__fstring__": [
+            "Search results from Google: \"",
+            {
+              "formatted": "No results found",
+              "source": "context",
+              "value": "No results found"
+            },
+            "\"\n\nAnswer the following question, using the search results if helpful:\n\nQuestion: \"",
+            {
+              "formatted": "Who is the president of the United States?",
+              "source": "question",
+              "value": "Who is the president of the United States?"
+            },
+            "\"\nAnswer: \""
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 1,
+      "shortArgs": [
+        "Search results from Google: \"",
+        "\"\n\nAnswer the following question, u...",
+        "\"\nAnswer: \""
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": "Mouth item identify school good general foot watch.",
+      "shortResult": [
+        "Mouth item identify school good gen..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Mouth item identify school good general foot watch.",
+      "shortResult": [
+        "Mouth item identify school good gen..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_search1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_search1].json
@@ -6,7 +6,9 @@
       },
       "name": "answer_by_search",
       "parent": 0,
-      "shortArgs": ["Who is the president of the United..."]
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
     }
   },
   {
@@ -16,7 +18,9 @@
       },
       "name": "search",
       "parent": 1,
-      "shortArgs": ["Who is the president of the United..."]
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
     }
   },
   {
@@ -24,7 +28,9 @@
       "result": {
         "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
       },
-      "shortResult": ["Invalid API key. Your API key shoul..."]
+      "shortResult": [
+        "Invalid API key. Your API key shoul..."
+      ]
     }
   },
   {
@@ -68,13 +74,17 @@
   {
     "3": {
       "result": "Mouth item identify school good general foot watch.",
-      "shortResult": ["Mouth item identify school good gen..."]
+      "shortResult": [
+        "Mouth item identify school good gen..."
+      ]
     }
   },
   {
     "1": {
       "result": "Mouth item identify school good general foot watch.",
-      "shortResult": ["Mouth item identify school good gen..."]
+      "shortResult": [
+        "Mouth item identify school good gen..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_by_search1].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_by_search1].json
@@ -6,9 +6,7 @@
       },
       "name": "answer_by_search",
       "parent": 0,
-      "shortArgs": [
-        "Who is the president of the United..."
-      ]
+      "shortArgs": ["Who is the president of the United..."]
     }
   },
   {
@@ -18,9 +16,7 @@
       },
       "name": "search",
       "parent": 1,
-      "shortArgs": [
-        "Who is the president of the United..."
-      ]
+      "shortArgs": ["Who is the president of the United..."]
     }
   },
   {
@@ -28,9 +24,7 @@
       "result": {
         "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
       },
-      "shortResult": [
-        "Invalid API key. Your API key shoul..."
-      ]
+      "shortResult": ["Invalid API key. Your API key shoul..."]
     }
   },
   {
@@ -74,17 +68,13 @@
   {
     "3": {
       "result": "Mouth item identify school good general foot watch.",
-      "shortResult": [
-        "Mouth item identify school good gen..."
-      ]
+      "shortResult": ["Mouth item identify school good gen..."]
     }
   },
   {
     "1": {
       "result": "Mouth item identify school good general foot watch.",
-      "shortResult": [
-        "Mouth item identify school good gen..."
-      ]
+      "shortResult": ["Mouth item identify school good gen..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper0].json
@@ -8,9 +8,7 @@
       },
       "name": "answer_for_paper",
       "parent": 0,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper0].json
@@ -1,0 +1,44 @@
+[
+  {
+    "1": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        }
+      },
+      "name": "answer_for_paper",
+      "parent": 0,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": {
+        "section_type": "abstract",
+        "sections": [
+          {
+            "number": "",
+            "title": "Abstract"
+          }
+        ],
+        "sentences": [
+          "In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo.",
+          "Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial.",
+          "Vital status was determined at subsequent censuses.",
+          "The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses.",
+          "Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger.",
+          "Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance.",
+          "(Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)"
+        ]
+      },
+      "shortResult": [
+        "In this cluster-randomized trial, w...",
+        "Children 1 to 59 months of age were...",
+        "Vital status was determined at subs...",
+        "..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper0].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper0].json
@@ -8,7 +8,9 @@
       },
       "name": "answer_for_paper",
       "parent": 0,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper2].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper2].json
@@ -1,0 +1,137 @@
+[
+  {
+    "1": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "question": "Pm ready almost special involve trouble open."
+      },
+      "name": "answer_for_paper",
+      "parent": 0,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paragraph": {
+          "section_type": "abstract",
+          "sections": [
+            {
+              "number": "",
+              "title": "Abstract"
+            }
+          ],
+          "sentences": [
+            "In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo.",
+            "Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial.",
+            "Vital status was determined at subsequent censuses.",
+            "The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses.",
+            "Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger.",
+            "Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance.",
+            "(Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)"
+          ]
+        },
+        "question": "Pm ready almost special involve trouble open."
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "In this cluster-randomized trial, w...",
+        "Children 1 to 59 months of age were...",
+        "Vital status was determined at subs...",
+        "..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo. Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial. Vital status was determined at subsequent censuses. The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses. Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger. Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance. (Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)",
+              "source": "paragraph",
+              "value": {
+                "section_type": "abstract",
+                "sections": [
+                  {
+                    "number": "",
+                    "title": "Abstract"
+                  }
+                ],
+                "sentences": [
+                  "In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo.",
+                  "Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial.",
+                  "Vital status was determined at subsequent censuses.",
+                  "The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses.",
+                  "Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger.",
+                  "Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance.",
+                  "(Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)"
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "Pm ready almost special involve trouble open.",
+              "source": "question",
+              "value": "Pm ready almost special involve trouble open."
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 2,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [
+        {
+          " No": 0.46540762596503044,
+          " Yes": 0.5345923740349696
+        },
+        null
+      ],
+      "shortResult": [
+        "0.5345923740349696"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": 0.5345923740349696,
+      "shortResult": [
+        "0.5345923740349696"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": 0.5345923740349696,
+      "shortResult": [
+        "0.5345923740349696"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper2].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper2].json
@@ -9,9 +9,7 @@
       },
       "name": "answer_for_paper",
       "parent": 0,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -50,10 +48,7 @@
   {
     "3": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -113,25 +108,19 @@
         },
         null
       ],
-      "shortResult": [
-        "0.5345923740349696"
-      ]
+      "shortResult": ["0.5345923740349696"]
     }
   },
   {
     "2": {
       "result": 0.5345923740349696,
-      "shortResult": [
-        "0.5345923740349696"
-      ]
+      "shortResult": ["0.5345923740349696"]
     }
   },
   {
     "1": {
       "result": 0.5345923740349696,
-      "shortResult": [
-        "0.5345923740349696"
-      ]
+      "shortResult": ["0.5345923740349696"]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper2].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper2].json
@@ -9,7 +9,9 @@
       },
       "name": "answer_for_paper",
       "parent": 0,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -48,7 +50,10 @@
   {
     "3": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -108,19 +113,25 @@
         },
         null
       ],
-      "shortResult": ["0.5345923740349696"]
+      "shortResult": [
+        "0.5345923740349696"
+      ]
     }
   },
   {
     "2": {
       "result": 0.5345923740349696,
-      "shortResult": ["0.5345923740349696"]
+      "shortResult": [
+        "0.5345923740349696"
+      ]
     }
   },
   {
     "1": {
       "result": 0.5345923740349696,
-      "shortResult": ["0.5345923740349696"]
+      "shortResult": [
+        "0.5345923740349696"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper3].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper3].json
@@ -9,9 +9,7 @@
       },
       "name": "answer_for_paper",
       "parent": 0,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -66,9 +64,7 @@
       },
       "name": "classify_paragraph",
       "parent": 1,
-      "shortArgs": [
-        "Trachoma-control programs have dist..."
-      ]
+      "shortArgs": ["Trachoma-control programs have dist..."]
     }
   },
   {
@@ -203,10 +199,7 @@
   {
     "8": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -266,18 +259,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.0649155225072023"
-      ]
+      "shortResult": ["0.0649155225072023"]
     }
   },
   {
     "9": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -331,18 +319,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.2340068525087361"
-      ]
+      "shortResult": ["0.2340068525087361"]
     }
   },
   {
     "10": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -402,18 +385,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.19000058663144304"
-      ]
+      "shortResult": ["0.19000058663144304"]
     }
   },
   {
     "11": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -474,18 +452,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.4886685449054451"
-      ]
+      "shortResult": ["0.4886685449054451"]
     }
   },
   {
     "12": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -544,18 +517,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.28402129551508437"
-      ]
+      "shortResult": ["0.28402129551508437"]
     }
   },
   {
     "13": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -612,72 +580,52 @@
         },
         null
       ],
-      "shortResult": [
-        "0.8547429543086006"
-      ]
+      "shortResult": ["0.8547429543086006"]
     }
   },
   {
     "2": {
       "result": 0.0649155225072023,
-      "shortResult": [
-        "0.0649155225072023"
-      ]
+      "shortResult": ["0.0649155225072023"]
     }
   },
   {
     "3": {
       "result": 0.2340068525087361,
-      "shortResult": [
-        "0.2340068525087361"
-      ]
+      "shortResult": ["0.2340068525087361"]
     }
   },
   {
     "4": {
       "result": 0.19000058663144304,
-      "shortResult": [
-        "0.19000058663144304"
-      ]
+      "shortResult": ["0.19000058663144304"]
     }
   },
   {
     "5": {
       "result": 0.4886685449054451,
-      "shortResult": [
-        "0.4886685449054451"
-      ]
+      "shortResult": ["0.4886685449054451"]
     }
   },
   {
     "6": {
       "result": 0.28402129551508437,
-      "shortResult": [
-        "0.28402129551508437"
-      ]
+      "shortResult": ["0.28402129551508437"]
     }
   },
   {
     "7": {
       "result": 0.8547429543086006,
-      "shortResult": [
-        "0.8547429543086006"
-      ]
+      "shortResult": ["0.8547429543086006"]
     }
   },
   {
     "1": {
       "result": [
-        0.0649155225072023,
-        0.2340068525087361,
-        0.19000058663144304,
-        0.4886685449054451,
-        0.28402129551508437,
-        0.8547429543086006
+        0.0649155225072023, 0.2340068525087361, 0.19000058663144304, 0.4886685449054451,
+        0.28402129551508437, 0.8547429543086006
       ],
-      "shortResult": [
-        "0.0649155225072023"
-      ]
+      "shortResult": ["0.0649155225072023"]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper3].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper3].json
@@ -9,7 +9,9 @@
       },
       "name": "answer_for_paper",
       "parent": 0,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -64,7 +66,9 @@
       },
       "name": "classify_paragraph",
       "parent": 1,
-      "shortArgs": ["Trachoma-control programs have dist..."]
+      "shortArgs": [
+        "Trachoma-control programs have dist..."
+      ]
     }
   },
   {
@@ -199,7 +203,10 @@
   {
     "8": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -259,13 +266,18 @@
         },
         null
       ],
-      "shortResult": ["0.0649155225072023"]
+      "shortResult": [
+        "0.0649155225072023"
+      ]
     }
   },
   {
     "9": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -319,13 +331,18 @@
         },
         null
       ],
-      "shortResult": ["0.2340068525087361"]
+      "shortResult": [
+        "0.2340068525087361"
+      ]
     }
   },
   {
     "10": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -385,13 +402,18 @@
         },
         null
       ],
-      "shortResult": ["0.19000058663144304"]
+      "shortResult": [
+        "0.19000058663144304"
+      ]
     }
   },
   {
     "11": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -452,13 +474,18 @@
         },
         null
       ],
-      "shortResult": ["0.4886685449054451"]
+      "shortResult": [
+        "0.4886685449054451"
+      ]
     }
   },
   {
     "12": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -517,13 +544,18 @@
         },
         null
       ],
-      "shortResult": ["0.28402129551508437"]
+      "shortResult": [
+        "0.28402129551508437"
+      ]
     }
   },
   {
     "13": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -580,52 +612,72 @@
         },
         null
       ],
-      "shortResult": ["0.8547429543086006"]
+      "shortResult": [
+        "0.8547429543086006"
+      ]
     }
   },
   {
     "2": {
       "result": 0.0649155225072023,
-      "shortResult": ["0.0649155225072023"]
+      "shortResult": [
+        "0.0649155225072023"
+      ]
     }
   },
   {
     "3": {
       "result": 0.2340068525087361,
-      "shortResult": ["0.2340068525087361"]
+      "shortResult": [
+        "0.2340068525087361"
+      ]
     }
   },
   {
     "4": {
       "result": 0.19000058663144304,
-      "shortResult": ["0.19000058663144304"]
+      "shortResult": [
+        "0.19000058663144304"
+      ]
     }
   },
   {
     "5": {
       "result": 0.4886685449054451,
-      "shortResult": ["0.4886685449054451"]
+      "shortResult": [
+        "0.4886685449054451"
+      ]
     }
   },
   {
     "6": {
       "result": 0.28402129551508437,
-      "shortResult": ["0.28402129551508437"]
+      "shortResult": [
+        "0.28402129551508437"
+      ]
     }
   },
   {
     "7": {
       "result": 0.8547429543086006,
-      "shortResult": ["0.8547429543086006"]
+      "shortResult": [
+        "0.8547429543086006"
+      ]
     }
   },
   {
     "1": {
       "result": [
-        0.0649155225072023, 0.2340068525087361, 0.19000058663144304, 0.4886685449054451,
-        0.28402129551508437, 0.8547429543086006
+        0.0649155225072023,
+        0.2340068525087361,
+        0.19000058663144304,
+        0.4886685449054451,
+        0.28402129551508437,
+        0.8547429543086006
       ],
-      "shortResult": ["0.0649155225072023"]
+      "shortResult": [
+        "0.0649155225072023"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper3].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper3].json
@@ -1,0 +1,683 @@
+[
+  {
+    "1": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "question": "What was the study population?"
+      },
+      "name": "answer_for_paper",
+      "parent": 0,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paragraph": {
+          "section_type": "abstract",
+          "sections": [
+            {
+              "number": "",
+              "title": "Abstract"
+            }
+          ],
+          "sentences": [
+            "In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo.",
+            "Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial.",
+            "Vital status was determined at subsequent censuses.",
+            "The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses.",
+            "Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger.",
+            "Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance.",
+            "(Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)"
+          ]
+        },
+        "question": "What was the study population?"
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "In this cluster-randomized trial, w...",
+        "Children 1 to 59 months of age were...",
+        "Vital status was determined at subs...",
+        "..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "paragraph": {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "1",
+              "title": "Introduction"
+            }
+          ],
+          "sentences": [
+            "Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17"
+          ]
+        },
+        "question": "What was the study population?"
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "Trachoma-control programs have dist..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "paragraph": {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "2",
+              "title": "Eligibility"
+            }
+          ],
+          "sentences": [
+            "MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization.",
+            "The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania.",
+            "None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin.",
+            "Enrollment was based on census information available before the trial.",
+            "Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org).",
+            "Communities remained in the trial even if the population drifted out of this range.",
+            "All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo."
+          ]
+        },
+        "question": "What was the study population?"
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "MORDOR (Macrolides Oraux pour R\u00e9dui...",
+        "The community that served as the ra...",
+        "None of the districts\nwere eligible...",
+        "..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "paragraph": {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "3",
+              "title": "Randomization and Masking"
+            }
+          ],
+          "sentences": [
+            "Lists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF).",
+            "For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org).",
+            "Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing).",
+            "Only key trial personnel were aware of which letters corresponded to each group.",
+            "Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments.",
+            "Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments.",
+            "The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin.",
+            "Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial."
+          ]
+        },
+        "question": "What was the study population?"
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "Lists of communities from the most...",
+        "For each country, communities were...",
+        "Randomization was performed with th...",
+        "..."
+      ]
+    }
+  },
+  {
+    "6": {
+      "args": {
+        "paragraph": {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "4",
+              "title": "Intervention"
+            }
+          ],
+          "sentences": [
+            "Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community).",
+            "Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand.",
+            "Children who were known to be allergic to macrolides were not given azithromycin or placebo.",
+            "Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage.",
+            "Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census.",
+            "The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF."
+          ]
+        },
+        "question": "What was the study population?"
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "Each child 1 to 59 months of age at...",
+        "Chil- dren were given a volume of s...",
+        "Children who were known to be aller...",
+        "..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "args": {
+        "paragraph": {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "5",
+              "title": "Primary Results"
+            }
+          ],
+          "sentences": [
+            "The results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups.",
+            "At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania).",
+            "Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001).",
+            "The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively)."
+          ]
+        },
+        "question": "What was the study population?"
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "The results of a 12-month interim a...",
+        "At the end of the trial, the annual...",
+        "Community-level, intention- to-trea...",
+        "..."
+      ]
+    }
+  },
+  {
+    "8": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo. Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial. Vital status was determined at subsequent censuses. The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses. Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger. Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance. (Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)",
+              "source": "paragraph",
+              "value": {
+                "section_type": "abstract",
+                "sections": [
+                  {
+                    "number": "",
+                    "title": "Abstract"
+                  }
+                ],
+                "sentences": [
+                  "In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo.",
+                  "Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial.",
+                  "Vital status was determined at subsequent censuses.",
+                  "The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses.",
+                  "Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger.",
+                  "Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance.",
+                  "(Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)"
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "What was the study population?",
+              "source": "question",
+              "value": "What was the study population?"
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 2,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "8": {
+      "result": [
+        {
+          " No": 0.9350844774927977,
+          " Yes": 0.0649155225072023
+        },
+        null
+      ],
+      "shortResult": [
+        "0.0649155225072023"
+      ]
+    }
+  },
+  {
+    "9": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17",
+              "source": "paragraph",
+              "value": {
+                "section_type": "main",
+                "sections": [
+                  {
+                    "number": "1",
+                    "title": "Introduction"
+                  }
+                ],
+                "sentences": [
+                  "Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17"
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "What was the study population?",
+              "source": "question",
+              "value": "What was the study population?"
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 3,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "9": {
+      "result": [
+        {
+          " No": 0.7659931474912639,
+          " Yes": 0.2340068525087361
+        },
+        null
+      ],
+      "shortResult": [
+        "0.2340068525087361"
+      ]
+    }
+  },
+  {
+    "10": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.",
+              "source": "paragraph",
+              "value": {
+                "section_type": "main",
+                "sections": [
+                  {
+                    "number": "2",
+                    "title": "Eligibility"
+                  }
+                ],
+                "sentences": [
+                  "MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization.",
+                  "The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania.",
+                  "None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin.",
+                  "Enrollment was based on census information available before the trial.",
+                  "Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org).",
+                  "Communities remained in the trial even if the population drifted out of this range.",
+                  "All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo."
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "What was the study population?",
+              "source": "question",
+              "value": "What was the study population?"
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 4,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "10": {
+      "result": [
+        {
+          " No": 0.809999413368557,
+          " Yes": 0.19000058663144304
+        },
+        null
+      ],
+      "shortResult": [
+        "0.19000058663144304"
+      ]
+    }
+  },
+  {
+    "11": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "Lists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF). For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org). Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing). Only key trial personnel were aware of which letters corresponded to each group. Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments. Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments. The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin. Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial.",
+              "source": "paragraph",
+              "value": {
+                "section_type": "main",
+                "sections": [
+                  {
+                    "number": "3",
+                    "title": "Randomization and Masking"
+                  }
+                ],
+                "sentences": [
+                  "Lists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF).",
+                  "For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org).",
+                  "Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing).",
+                  "Only key trial personnel were aware of which letters corresponded to each group.",
+                  "Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments.",
+                  "Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments.",
+                  "The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin.",
+                  "Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial."
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "What was the study population?",
+              "source": "question",
+              "value": "What was the study population?"
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 5,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "11": {
+      "result": [
+        {
+          " No": 0.511331455094555,
+          " Yes": 0.4886685449054451
+        },
+        null
+      ],
+      "shortResult": [
+        "0.4886685449054451"
+      ]
+    }
+  },
+  {
+    "12": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.",
+              "source": "paragraph",
+              "value": {
+                "section_type": "main",
+                "sections": [
+                  {
+                    "number": "4",
+                    "title": "Intervention"
+                  }
+                ],
+                "sentences": [
+                  "Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community).",
+                  "Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand.",
+                  "Children who were known to be allergic to macrolides were not given azithromycin or placebo.",
+                  "Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage.",
+                  "Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census.",
+                  "The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF."
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "What was the study population?",
+              "source": "question",
+              "value": "What was the study population?"
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 6,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "12": {
+      "result": [
+        {
+          " No": 0.7159787044849156,
+          " Yes": 0.28402129551508437
+        },
+        null
+      ],
+      "shortResult": [
+        "0.28402129551508437"
+      ]
+    }
+  },
+  {
+    "13": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "The results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups. At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania). Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001). The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively).",
+              "source": "paragraph",
+              "value": {
+                "section_type": "main",
+                "sections": [
+                  {
+                    "number": "5",
+                    "title": "Primary Results"
+                  }
+                ],
+                "sentences": [
+                  "The results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups.",
+                  "At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania).",
+                  "Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001).",
+                  "The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively)."
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "What was the study population?",
+              "source": "question",
+              "value": "What was the study population?"
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 7,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "13": {
+      "result": [
+        {
+          " No": 0.14525704569139938,
+          " Yes": 0.8547429543086006
+        },
+        null
+      ],
+      "shortResult": [
+        "0.8547429543086006"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": 0.0649155225072023,
+      "shortResult": [
+        "0.0649155225072023"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": 0.2340068525087361,
+      "shortResult": [
+        "0.2340068525087361"
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": 0.19000058663144304,
+      "shortResult": [
+        "0.19000058663144304"
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": 0.4886685449054451,
+      "shortResult": [
+        "0.4886685449054451"
+      ]
+    }
+  },
+  {
+    "6": {
+      "result": 0.28402129551508437,
+      "shortResult": [
+        "0.28402129551508437"
+      ]
+    }
+  },
+  {
+    "7": {
+      "result": 0.8547429543086006,
+      "shortResult": [
+        "0.8547429543086006"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": [
+        0.0649155225072023,
+        0.2340068525087361,
+        0.19000058663144304,
+        0.4886685449054451,
+        0.28402129551508437,
+        0.8547429543086006
+      ],
+      "shortResult": [
+        "0.0649155225072023"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper4].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper4].json
@@ -1,0 +1,732 @@
+[
+  {
+    "1": {
+      "args": {
+        "paper": {
+          "document_id": "keenan-2018-tiny.txt"
+        },
+        "question": "Result decide list.",
+        "top_n": 3
+      },
+      "name": "answer_for_paper",
+      "parent": 0,
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "paragraph": {
+          "section_type": "abstract",
+          "sections": [
+            {
+              "number": "",
+              "title": "Abstract"
+            }
+          ],
+          "sentences": [
+            "In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo.",
+            "Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial.",
+            "Vital status was determined at subsequent censuses.",
+            "The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses.",
+            "Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger.",
+            "Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance.",
+            "(Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)"
+          ]
+        },
+        "question": "Result decide list."
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "In this cluster-randomized trial, w...",
+        "Children 1 to 59 months of age were...",
+        "Vital status was determined at subs...",
+        "..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "paragraph": {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "1",
+              "title": "Introduction"
+            }
+          ],
+          "sentences": [
+            "Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17"
+          ]
+        },
+        "question": "Result decide list."
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "Trachoma-control programs have dist..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "paragraph": {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "2",
+              "title": "Eligibility"
+            }
+          ],
+          "sentences": [
+            "MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization.",
+            "The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania.",
+            "None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin.",
+            "Enrollment was based on census information available before the trial.",
+            "Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org).",
+            "Communities remained in the trial even if the population drifted out of this range.",
+            "All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo."
+          ]
+        },
+        "question": "Result decide list."
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "MORDOR (Macrolides Oraux pour R\u00e9dui...",
+        "The community that served as the ra...",
+        "None of the districts\nwere eligible...",
+        "..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "paragraph": {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "3",
+              "title": "Randomization and Masking"
+            }
+          ],
+          "sentences": [
+            "Lists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF).",
+            "For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org).",
+            "Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing).",
+            "Only key trial personnel were aware of which letters corresponded to each group.",
+            "Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments.",
+            "Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments.",
+            "The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin.",
+            "Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial."
+          ]
+        },
+        "question": "Result decide list."
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "Lists of communities from the most...",
+        "For each country, communities were...",
+        "Randomization was performed with th...",
+        "..."
+      ]
+    }
+  },
+  {
+    "6": {
+      "args": {
+        "paragraph": {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "4",
+              "title": "Intervention"
+            }
+          ],
+          "sentences": [
+            "Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community).",
+            "Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand.",
+            "Children who were known to be allergic to macrolides were not given azithromycin or placebo.",
+            "Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage.",
+            "Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census.",
+            "The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF."
+          ]
+        },
+        "question": "Result decide list."
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "Each child 1 to 59 months of age at...",
+        "Chil- dren were given a volume of s...",
+        "Children who were known to be aller...",
+        "..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "args": {
+        "paragraph": {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "5",
+              "title": "Primary Results"
+            }
+          ],
+          "sentences": [
+            "The results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups.",
+            "At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania).",
+            "Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001).",
+            "The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively)."
+          ]
+        },
+        "question": "Result decide list."
+      },
+      "name": "classify_paragraph",
+      "parent": 1,
+      "shortArgs": [
+        "The results of a 12-month interim a...",
+        "At the end of the trial, the annual...",
+        "Community-level, intention- to-trea...",
+        "..."
+      ]
+    }
+  },
+  {
+    "8": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo. Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial. Vital status was determined at subsequent censuses. The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses. Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger. Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance. (Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)",
+              "source": "paragraph",
+              "value": {
+                "section_type": "abstract",
+                "sections": [
+                  {
+                    "number": "",
+                    "title": "Abstract"
+                  }
+                ],
+                "sentences": [
+                  "In this cluster-randomized trial, we assigned communities in Malawi, Niger, and Tanzania to four twice-yearly mass distributions of either oral azithromycin (approxi- mately 20 mg per kilogram of body weight) or placebo.",
+                  "Children 1 to 59 months of age were identified in twice-yearly censuses and were offered participation in the trial.",
+                  "Vital status was determined at subsequent censuses.",
+                  "The primary outcome was aggregate all-cause mortality; country-specific rates were assessed in prespecified subgroup analyses.",
+                  "Among postneonatal, preschool children in sub-Saharan Africa, childhood mortality was lower in communities randomly assigned to mass distribution of azithromycin than in those assigned to placebo, with the largest effect seen in Niger.",
+                  "Any imple- mentation of a policy of mass distribution would need to strongly consider the poten- tial effect of such a strategy on antibiotic resistance.",
+                  "(Funded by the Bill and Melinda Gates Foundation; MORDOR ClinicalTrials.gov number, NCT02047981.)"
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "Result decide list.",
+              "source": "question",
+              "value": "Result decide list."
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 2,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "8": {
+      "result": [
+        {
+          " No": 0.9308702443780423,
+          " Yes": 0.06912975562195772
+        },
+        null
+      ],
+      "shortResult": [
+        "0.06912975562195772"
+      ]
+    }
+  },
+  {
+    "9": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17",
+              "source": "paragraph",
+              "value": {
+                "section_type": "main",
+                "sections": [
+                  {
+                    "number": "1",
+                    "title": "Introduction"
+                  }
+                ],
+                "sentences": [
+                  "Trachoma-control programs have distributed more than 600 million doses of oral azithromycin in an effort to elimi- nate the ocular strains of chlamydia that cause the disease.1,2 Azithromycin has been effective against trachoma, although it has caused gastro- intestinal side effects and selected for macrolide- resistant strains of Streptococcus pneumoniae and Escherichia coli.3-8 Investigators have also noted possible benefits of azithromycin for prevention of a number of infectious diseases including malaria, infectious diarrhea, and pneumonia.9-14 The results of a case\u2013control study and a cluster- randomized trial in an area of Ethiopia in which trachoma is endemic suggested that mass distri- bution of azithromycin might reduce childhood mortality.15,16 Some experts believed that a mor- tality benefit was, indeed, possible, although it would probably be smaller in magnitude than what was found in these studies.17"
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "Result decide list.",
+              "source": "question",
+              "value": "Result decide list."
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 3,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "9": {
+      "result": [
+        {
+          " No": 0.4114102344703187,
+          " Yes": 0.5885897655296813
+        },
+        null
+      ],
+      "shortResult": [
+        "0.5885897655296813"
+      ]
+    }
+  },
+  {
+    "10": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization. The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania. None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin. Enrollment was based on census information available before the trial. Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org). Communities remained in the trial even if the population drifted out of this range. All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo.",
+              "source": "paragraph",
+              "value": {
+                "section_type": "main",
+                "sections": [
+                  {
+                    "number": "2",
+                    "title": "Eligibility"
+                  }
+                ],
+                "sentences": [
+                  "MORDOR (Macrolides Oraux pour R\u00e9duire les D\u00e9c\u00e8s avec un Oeil sur la R\u00e9sistance) was a cluster-randomized trial conducted in the Mala- wian district of Mangochi, in the Nigerien dis- tricts of Boboye and Loga, and in the Tanzanian districts of Kilosa and Gairo, with communities as the unit of randomization.",
+                  "The community that served as the randomization unit was a health surveillance assistance area in Malawi, a grappe (i.e., a cluster of households representing the smallest government health unit) in Niger, and a hamlet in Tanzania.",
+                  "None of the districts\nwere eligible for mass distributions of azithro- mycin for trachoma on the basis of the most recent mapping, and none of the children who participated in the trial had previously received azithromycin.",
+                  "Enrollment was based on census information available before the trial.",
+                  "Commu- nities with a population between 200 and 2000 inhabitants on the most recent census were eli- gible for enrollment (see the Supplementary Ap- pendix, available with the full text of this article at NEJM.org).",
+                  "Communities remained in the trial even if the population drifted out of this range.",
+                  "All children 1 to 59 months of age (truncated to month) who weighed at least 3800 g were eligi- ble to receive azithromycin or placebo."
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "Result decide list.",
+              "source": "question",
+              "value": "Result decide list."
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 4,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "10": {
+      "result": [
+        {
+          " No": 0.3104990731618265,
+          " Yes": 0.6895009268381735
+        },
+        null
+      ],
+      "shortResult": [
+        "0.6895009268381735"
+      ]
+    }
+  },
+  {
+    "11": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "Lists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF). For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org). Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing). Only key trial personnel were aware of which letters corresponded to each group. Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments. Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments. The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin. Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial.",
+              "source": "paragraph",
+              "value": {
+                "section_type": "main",
+                "sections": [
+                  {
+                    "number": "3",
+                    "title": "Randomization and Masking"
+                  }
+                ],
+                "sentences": [
+                  "Lists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF).",
+                  "For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org).",
+                  "Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing).",
+                  "Only key trial personnel were aware of which letters corresponded to each group.",
+                  "Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments.",
+                  "Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments.",
+                  "The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin.",
+                  "Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial."
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "Result decide list.",
+              "source": "question",
+              "value": "Result decide list."
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 5,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "11": {
+      "result": [
+        {
+          " No": 0.15194608540546886,
+          " Yes": 0.8480539145945312
+        },
+        null
+      ],
+      "shortResult": [
+        "0.8480539145945312"
+      ]
+    }
+  },
+  {
+    "12": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community). Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand. Children who were known to be allergic to macrolides were not given azithromycin or placebo. Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage. Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census. The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF.",
+              "source": "paragraph",
+              "value": {
+                "section_type": "main",
+                "sections": [
+                  {
+                    "number": "4",
+                    "title": "Intervention"
+                  }
+                ],
+                "sentences": [
+                  "Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community).",
+                  "Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand.",
+                  "Children who were known to be allergic to macrolides were not given azithromycin or placebo.",
+                  "Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage.",
+                  "Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census.",
+                  "The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF."
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "Result decide list.",
+              "source": "question",
+              "value": "Result decide list."
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 6,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "12": {
+      "result": [
+        {
+          " No": 0.19406778471371455,
+          " Yes": 0.8059322152862854
+        },
+        null
+      ],
+      "shortResult": [
+        "0.8059322152862854"
+      ]
+    }
+  },
+  {
+    "13": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Here is a paragraph from a research paper: \"",
+            {
+              "formatted": "The results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups. At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania). Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001). The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively).",
+              "source": "paragraph",
+              "value": {
+                "section_type": "main",
+                "sections": [
+                  {
+                    "number": "5",
+                    "title": "Primary Results"
+                  }
+                ],
+                "sentences": [
+                  "The results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups.",
+                  "At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania).",
+                  "Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001).",
+                  "The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively)."
+                ]
+              }
+            },
+            "\"\n\nQuestion: Does this paragraph answer the question '",
+            {
+              "formatted": "Result decide list.",
+              "source": "question",
+              "value": "Result decide list."
+            },
+            "'? Say Yes or No.\nAnswer:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 7,
+      "shortArgs": [
+        "Here is a paragraph from a research...",
+        "\"\n\nQuestion: Does this paragraph an...",
+        "'? Say Yes or No.\nAnswer:"
+      ]
+    }
+  },
+  {
+    "13": {
+      "result": [
+        {
+          " No": 0.26327220482252744,
+          " Yes": 0.7367277951774727
+        },
+        null
+      ],
+      "shortResult": [
+        "0.7367277951774727"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": 0.06912975562195772,
+      "shortResult": [
+        "0.06912975562195772"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": 0.5885897655296813,
+      "shortResult": [
+        "0.5885897655296813"
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": 0.6895009268381735,
+      "shortResult": [
+        "0.6895009268381735"
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": 0.8480539145945312,
+      "shortResult": [
+        "0.8480539145945312"
+      ]
+    }
+  },
+  {
+    "6": {
+      "result": 0.8059322152862854,
+      "shortResult": [
+        "0.8059322152862854"
+      ]
+    }
+  },
+  {
+    "7": {
+      "result": 0.7367277951774727,
+      "shortResult": [
+        "0.7367277951774727"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": [
+        {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "3",
+              "title": "Randomization and Masking"
+            }
+          ],
+          "sentences": [
+            "Lists of communities from the most recent pre- trial census were submitted to the data coordi- nating center at the University of California, San Francisco (UCSF).",
+            "For each country, communities were randomly assigned in equal proportions to 1 of 10 letters, with 5 letters coded for azithro- mycin and 5 for placebo (more information is provided in the statistical analysis plan in the protocol, available at NEJM.org).",
+            "Randomization was performed with the sample function in R soft- ware, version 3.1 (R Foundation for Statistical Computing).",
+            "Only key trial personnel were aware of which letters corresponded to each group.",
+            "Participants, observers, investigators, and data- cleaning team members were unaware of the group assignments.",
+            "Centralized randomization and simultaneous assignment of communities facilitated complete concealment of the assign- ments.",
+            "The placebo contained the vehicle of the oral azithromycin suspension and was bottled and labeled identically to azithromycin.",
+            "Both placebo and azithromycin were donated by Pfizer, which reviewed the protocol but had no other role in the trial."
+          ]
+        },
+        {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "4",
+              "title": "Intervention"
+            }
+          ],
+          "sentences": [
+            "Each child 1 to 59 months of age at the time of the census was offered a single directly observed dose of oral azithromycin or placebo (according to the randomization of their community).",
+            "Chil- dren were given a volume of suspension corre- sponding to at least 20 mg per kilogram of body weight, calculated with the use of a height stick (see the protocol), in accordance with the coun- try\u2019s trachoma program guidelines, or by weight for children unable to stand.",
+            "Children who were known to be allergic to macrolides were not given azithromycin or placebo.",
+            "Azithromycin or placebo was administered at the time of the census or during additional visits in an attempt to achieve at least 80% coverage.",
+            "Administration of trial medication or placebo was documented in the mobile application for each child, and com- munity coverage was calculated relative to the census.",
+            "The parents or guardians of the children and the local health posts were instructed to contact a village representative regarding any adverse events noted within 7 days after admin- istration of azithromycin or placebo; the village representative reported the events to the site coor- dinator, who in turn reported the events to UCSF."
+          ]
+        },
+        {
+          "section_type": "main",
+          "sections": [
+            {
+              "number": "5",
+              "title": "Primary Results"
+            }
+          ],
+          "sentences": [
+            "The results of a 12-month interim analysis for efficacy did not meet the prespecified criterion for early stopping, which was a P value of less than 0.001 for the difference between groups.",
+            "At the end of the trial, the annual mortality rate for eligible children in the three countries combined was 14.6 deaths per 1000 person-years in com- munities that received azithromycin (9.1 per 1000 person-years in Malawi, 22.5 in Niger, and 5.4 in Tanzania) and 16.5 deaths per 1000 person- years in communities that received placebo (9.6 per 1000 person-years in Malawi, 27.5 in Niger, and 5.5 in Tanzania).",
+            "Community-level, intention- to-treat analysis showed that over all four inter- censal periods, mortality was 13.5% lower over- all (95% confidence interval [CI], 6.7 to 19.8) in the azithromycin group than in the placebo group (P<0.001).",
+            "The proportion of children whose census status was recorded as moved or unknown did not differ significantly between the groups (P=0.71 and P=0.36, respectively)."
+          ]
+        }
+      ],
+      "shortResult": [
+        "Lists of communities from the most...",
+        "For each country, communities were...",
+        "Randomization was performed with th...",
+        "..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper4].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper4].json
@@ -10,7 +10,9 @@
       },
       "name": "answer_for_paper",
       "parent": 0,
-      "shortArgs": ["keenan-2018-tiny.txt"]
+      "shortArgs": [
+        "keenan-2018-tiny.txt"
+      ]
     }
   },
   {
@@ -65,7 +67,9 @@
       },
       "name": "classify_paragraph",
       "parent": 1,
-      "shortArgs": ["Trachoma-control programs have dist..."]
+      "shortArgs": [
+        "Trachoma-control programs have dist..."
+      ]
     }
   },
   {
@@ -200,7 +204,10 @@
   {
     "8": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -260,13 +267,18 @@
         },
         null
       ],
-      "shortResult": ["0.06912975562195772"]
+      "shortResult": [
+        "0.06912975562195772"
+      ]
     }
   },
   {
     "9": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -320,13 +332,18 @@
         },
         null
       ],
-      "shortResult": ["0.5885897655296813"]
+      "shortResult": [
+        "0.5885897655296813"
+      ]
     }
   },
   {
     "10": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -386,13 +403,18 @@
         },
         null
       ],
-      "shortResult": ["0.6895009268381735"]
+      "shortResult": [
+        "0.6895009268381735"
+      ]
     }
   },
   {
     "11": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -453,13 +475,18 @@
         },
         null
       ],
-      "shortResult": ["0.8480539145945312"]
+      "shortResult": [
+        "0.8480539145945312"
+      ]
     }
   },
   {
     "12": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -518,13 +545,18 @@
         },
         null
       ],
-      "shortResult": ["0.8059322152862854"]
+      "shortResult": [
+        "0.8059322152862854"
+      ]
     }
   },
   {
     "13": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -581,43 +613,57 @@
         },
         null
       ],
-      "shortResult": ["0.7367277951774727"]
+      "shortResult": [
+        "0.7367277951774727"
+      ]
     }
   },
   {
     "2": {
       "result": 0.06912975562195772,
-      "shortResult": ["0.06912975562195772"]
+      "shortResult": [
+        "0.06912975562195772"
+      ]
     }
   },
   {
     "3": {
       "result": 0.5885897655296813,
-      "shortResult": ["0.5885897655296813"]
+      "shortResult": [
+        "0.5885897655296813"
+      ]
     }
   },
   {
     "4": {
       "result": 0.6895009268381735,
-      "shortResult": ["0.6895009268381735"]
+      "shortResult": [
+        "0.6895009268381735"
+      ]
     }
   },
   {
     "5": {
       "result": 0.8480539145945312,
-      "shortResult": ["0.8480539145945312"]
+      "shortResult": [
+        "0.8480539145945312"
+      ]
     }
   },
   {
     "6": {
       "result": 0.8059322152862854,
-      "shortResult": ["0.8059322152862854"]
+      "shortResult": [
+        "0.8059322152862854"
+      ]
     }
   },
   {
     "7": {
       "result": 0.7367277951774727,
-      "shortResult": ["0.7367277951774727"]
+      "shortResult": [
+        "0.7367277951774727"
+      ]
     }
   },
   {

--- a/tests/expected_traces/test_all_primer_recipes[answer_for_paper4].json
+++ b/tests/expected_traces/test_all_primer_recipes[answer_for_paper4].json
@@ -10,9 +10,7 @@
       },
       "name": "answer_for_paper",
       "parent": 0,
-      "shortArgs": [
-        "keenan-2018-tiny.txt"
-      ]
+      "shortArgs": ["keenan-2018-tiny.txt"]
     }
   },
   {
@@ -67,9 +65,7 @@
       },
       "name": "classify_paragraph",
       "parent": 1,
-      "shortArgs": [
-        "Trachoma-control programs have dist..."
-      ]
+      "shortArgs": ["Trachoma-control programs have dist..."]
     }
   },
   {
@@ -204,10 +200,7 @@
   {
     "8": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -267,18 +260,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.06912975562195772"
-      ]
+      "shortResult": ["0.06912975562195772"]
     }
   },
   {
     "9": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -332,18 +320,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.5885897655296813"
-      ]
+      "shortResult": ["0.5885897655296813"]
     }
   },
   {
     "10": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -403,18 +386,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.6895009268381735"
-      ]
+      "shortResult": ["0.6895009268381735"]
     }
   },
   {
     "11": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -475,18 +453,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.8480539145945312"
-      ]
+      "shortResult": ["0.8480539145945312"]
     }
   },
   {
     "12": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -545,18 +518,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.8059322152862854"
-      ]
+      "shortResult": ["0.8059322152862854"]
     }
   },
   {
     "13": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -613,57 +581,43 @@
         },
         null
       ],
-      "shortResult": [
-        "0.7367277951774727"
-      ]
+      "shortResult": ["0.7367277951774727"]
     }
   },
   {
     "2": {
       "result": 0.06912975562195772,
-      "shortResult": [
-        "0.06912975562195772"
-      ]
+      "shortResult": ["0.06912975562195772"]
     }
   },
   {
     "3": {
       "result": 0.5885897655296813,
-      "shortResult": [
-        "0.5885897655296813"
-      ]
+      "shortResult": ["0.5885897655296813"]
     }
   },
   {
     "4": {
       "result": 0.6895009268381735,
-      "shortResult": [
-        "0.6895009268381735"
-      ]
+      "shortResult": ["0.6895009268381735"]
     }
   },
   {
     "5": {
       "result": 0.8480539145945312,
-      "shortResult": [
-        "0.8480539145945312"
-      ]
+      "shortResult": ["0.8480539145945312"]
     }
   },
   {
     "6": {
       "result": 0.8059322152862854,
-      "shortResult": [
-        "0.8059322152862854"
-      ]
+      "shortResult": ["0.8059322152862854"]
     }
   },
   {
     "7": {
       "result": 0.7367277951774727,
-      "shortResult": [
-        "0.7367277951774727"
-      ]
+      "shortResult": ["0.7367277951774727"]
     }
   },
   {

--- a/tests/expected_traces/test_all_primer_recipes[ask_subquestions].json
+++ b/tests/expected_traces/test_all_primer_recipes[ask_subquestions].json
@@ -6,9 +6,7 @@
       },
       "name": "ask_subquestions",
       "parent": 0,
-      "shortArgs": [
-        "What is the effect of creatine on c..."
-      ]
+      "shortArgs": ["What is the effect of creatine on c..."]
     }
   },
   {
@@ -36,28 +34,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 1,
-      "shortArgs": [
-        "Decompose the following question in...",
-        "\"\nSubquestions:\n-"
-      ]
+      "shortArgs": ["Decompose the following question in...", "\"\nSubquestions:\n-"]
     }
   },
   {
     "2": {
       "result": "Low either deep painting finally certain approach.",
-      "shortResult": [
-        "Low either deep painting finally ce..."
-      ]
+      "shortResult": ["Low either deep painting finally ce..."]
     }
   },
   {
     "1": {
-      "result": [
-        "Low either deep painting finally certain approach."
-      ],
-      "shortResult": [
-        "Low either deep painting finally ce..."
-      ]
+      "result": ["Low either deep painting finally certain approach."],
+      "shortResult": ["Low either deep painting finally ce..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[ask_subquestions].json
+++ b/tests/expected_traces/test_all_primer_recipes[ask_subquestions].json
@@ -1,0 +1,63 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "What is the effect of creatine on cognition?"
+      },
+      "name": "ask_subquestions",
+      "parent": 0,
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Decompose the following question into 2-5 subquestions that would help you answer the question. Make the questions stand alone, so that they can be answered without the context of the original question.\n\nQuestion: \"",
+            {
+              "formatted": "What is the effect of creatine on cognition?",
+              "source": "question",
+              "value": "What is the effect of creatine on cognition?"
+            },
+            "\"\nSubquestions:\n-"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 1,
+      "shortArgs": [
+        "Decompose the following question in...",
+        "\"\nSubquestions:\n-"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Low either deep painting finally certain approach.",
+      "shortResult": [
+        "Low either deep painting finally ce..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": [
+        "Low either deep painting finally certain approach."
+      ],
+      "shortResult": [
+        "Low either deep painting finally ce..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[ask_subquestions].json
+++ b/tests/expected_traces/test_all_primer_recipes[ask_subquestions].json
@@ -6,7 +6,9 @@
       },
       "name": "ask_subquestions",
       "parent": 0,
-      "shortArgs": ["What is the effect of creatine on c..."]
+      "shortArgs": [
+        "What is the effect of creatine on c..."
+      ]
     }
   },
   {
@@ -34,19 +36,28 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 1,
-      "shortArgs": ["Decompose the following question in...", "\"\nSubquestions:\n-"]
+      "shortArgs": [
+        "Decompose the following question in...",
+        "\"\nSubquestions:\n-"
+      ]
     }
   },
   {
     "2": {
       "result": "Low either deep painting finally certain approach.",
-      "shortResult": ["Low either deep painting finally ce..."]
+      "shortResult": [
+        "Low either deep painting finally ce..."
+      ]
     }
   },
   {
     "1": {
-      "result": ["Low either deep painting finally certain approach."],
-      "shortResult": ["Low either deep painting finally ce..."]
+      "result": [
+        "Low either deep painting finally certain approach."
+      ],
+      "shortResult": [
+        "Low either deep painting finally ce..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[chain_of_thought].json
+++ b/tests/expected_traces/test_all_primer_recipes[chain_of_thought].json
@@ -1,0 +1,67 @@
+[
+  {
+    "1": {
+      "args": {
+        "answer_prefix": "Let's think step by step.",
+        "question": "What would happen if the average temperature in Northern California went up by 5 degrees Fahrenheit?"
+      },
+      "name": "chain_of_thought",
+      "parent": 0,
+      "shortArgs": [
+        "What would happen if the average te..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "Answer the following question:\n\nQuestion: \"",
+            {
+              "formatted": "What would happen if the average temperature in Northern California went up by 5 degrees Fahrenheit?",
+              "source": "question",
+              "value": "What would happen if the average temperature in Northern California went up by 5 degrees Fahrenheit?"
+            },
+            "\"\nAnswer: \"",
+            {
+              "formatted": "Let's think step by step.",
+              "source": "answer_prefix",
+              "value": "Let's think step by step."
+            }
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 1,
+      "shortArgs": [
+        "Answer the following question:\n\nQue...",
+        "\"\nAnswer: \""
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Strategy check teacher benefit easy daughter offer not.",
+      "shortResult": [
+        "Strategy check teacher benefit easy..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Strategy check teacher benefit easy daughter offer not.",
+      "shortResult": [
+        "Strategy check teacher benefit easy..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[chain_of_thought].json
+++ b/tests/expected_traces/test_all_primer_recipes[chain_of_thought].json
@@ -7,7 +7,9 @@
       },
       "name": "chain_of_thought",
       "parent": 0,
-      "shortArgs": ["What would happen if the average te..."]
+      "shortArgs": [
+        "What would happen if the average te..."
+      ]
     }
   },
   {
@@ -40,19 +42,26 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 1,
-      "shortArgs": ["Answer the following question:\n\nQue...", "\"\nAnswer: \""]
+      "shortArgs": [
+        "Answer the following question:\n\nQue...",
+        "\"\nAnswer: \""
+      ]
     }
   },
   {
     "2": {
       "result": "Strategy check teacher benefit easy daughter offer not.",
-      "shortResult": ["Strategy check teacher benefit easy..."]
+      "shortResult": [
+        "Strategy check teacher benefit easy..."
+      ]
     }
   },
   {
     "1": {
       "result": "Strategy check teacher benefit easy daughter offer not.",
-      "shortResult": ["Strategy check teacher benefit easy..."]
+      "shortResult": [
+        "Strategy check teacher benefit easy..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[chain_of_thought].json
+++ b/tests/expected_traces/test_all_primer_recipes[chain_of_thought].json
@@ -7,9 +7,7 @@
       },
       "name": "chain_of_thought",
       "parent": 0,
-      "shortArgs": [
-        "What would happen if the average te..."
-      ]
+      "shortArgs": ["What would happen if the average te..."]
     }
   },
   {
@@ -42,26 +40,19 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 1,
-      "shortArgs": [
-        "Answer the following question:\n\nQue...",
-        "\"\nAnswer: \""
-      ]
+      "shortArgs": ["Answer the following question:\n\nQue...", "\"\nAnswer: \""]
     }
   },
   {
     "2": {
       "result": "Strategy check teacher benefit easy daughter offer not.",
-      "shortResult": [
-        "Strategy check teacher benefit easy..."
-      ]
+      "shortResult": ["Strategy check teacher benefit easy..."]
     }
   },
   {
     "1": {
       "result": "Strategy check teacher benefit easy daughter offer not.",
-      "shortResult": [
-        "Strategy check teacher benefit easy..."
-      ]
+      "shortResult": ["Strategy check teacher benefit easy..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[eval_selective].json
+++ b/tests/expected_traces/test_all_primer_recipes[eval_selective].json
@@ -6,7 +6,9 @@
       },
       "name": "eval_selective",
       "parent": 0,
-      "shortArgs": ["Pass both left character explain si..."]
+      "shortArgs": [
+        "Pass both left character explain si..."
+      ]
     }
   },
   {
@@ -16,7 +18,9 @@
       },
       "name": "choose_computation",
       "parent": 1,
-      "shortArgs": ["Pass both left character explain si..."]
+      "shortArgs": [
+        "Pass both left character explain si..."
+      ]
     }
   },
   {
@@ -53,13 +57,17 @@
   {
     "3": {
       "result": "Example with several perhaps sound write.",
-      "shortResult": ["Example with several perhaps sound..."]
+      "shortResult": [
+        "Example with several perhaps sound..."
+      ]
     }
   },
   {
     "2": {
       "result": "Example with several perhaps sound write.",
-      "shortResult": ["Example with several perhaps sound..."]
+      "shortResult": [
+        "Example with several perhaps sound..."
+      ]
     }
   },
   {

--- a/tests/expected_traces/test_all_primer_recipes[eval_selective].json
+++ b/tests/expected_traces/test_all_primer_recipes[eval_selective].json
@@ -1,0 +1,85 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "Pass both left character explain sit friend."
+      },
+      "name": "eval_selective",
+      "parent": 0,
+      "shortArgs": [
+        "Pass both left character explain si..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "question": "Pass both left character explain sit friend."
+      },
+      "name": "choose_computation",
+      "parent": 1,
+      "shortArgs": [
+        "Pass both left character explain si..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            "You've been asked to answer the question \"",
+            {
+              "formatted": "Pass both left character explain sit friend.",
+              "source": "question",
+              "value": "Pass both left character explain sit friend."
+            },
+            "\".\n\nYou have access to a Python interpreter.\n\nEnter an expression that will help you answer the question.\n>>>"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": "\"",
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 2,
+      "shortArgs": [
+        "You've been asked to answer the que...",
+        "\".\n\nYou have access to a Python int..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": "Example with several perhaps sound write.",
+      "shortResult": [
+        "Example with several perhaps sound..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": "Example with several perhaps sound write.",
+      "shortResult": [
+        "Example with several perhaps sound..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": [
+        "Example with several perhaps sound write.",
+        "Error: invalid syntax (<string>, line 1)"
+      ],
+      "shortResult": [
+        "Example with several perhaps sound...",
+        "Error: invalid syntax (<string>, li..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[eval_selective].json
+++ b/tests/expected_traces/test_all_primer_recipes[eval_selective].json
@@ -6,9 +6,7 @@
       },
       "name": "eval_selective",
       "parent": 0,
-      "shortArgs": [
-        "Pass both left character explain si..."
-      ]
+      "shortArgs": ["Pass both left character explain si..."]
     }
   },
   {
@@ -18,9 +16,7 @@
       },
       "name": "choose_computation",
       "parent": 1,
-      "shortArgs": [
-        "Pass both left character explain si..."
-      ]
+      "shortArgs": ["Pass both left character explain si..."]
     }
   },
   {
@@ -57,17 +53,13 @@
   {
     "3": {
       "result": "Example with several perhaps sound write.",
-      "shortResult": [
-        "Example with several perhaps sound..."
-      ]
+      "shortResult": ["Example with several perhaps sound..."]
     }
   },
   {
     "2": {
       "result": "Example with several perhaps sound write.",
-      "shortResult": [
-        "Example with several perhaps sound..."
-      ]
+      "shortResult": ["Example with several perhaps sound..."]
     }
   },
   {

--- a/tests/expected_traces/test_all_primer_recipes[say_hello].json
+++ b/tests/expected_traces/test_all_primer_recipes[say_hello].json
@@ -1,0 +1,20 @@
+[
+  {
+    "1": {
+      "args": {},
+      "name": "say_hello",
+      "parent": 0,
+      "shortArgs": [
+        "()"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Hello world!",
+      "shortResult": [
+        "Hello world!"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[say_hello].json
+++ b/tests/expected_traces/test_all_primer_recipes[say_hello].json
@@ -4,17 +4,13 @@
       "args": {},
       "name": "say_hello",
       "parent": 0,
-      "shortArgs": [
-        "()"
-      ]
+      "shortArgs": ["()"]
     }
   },
   {
     "1": {
       "result": "Hello world!",
-      "shortResult": [
-        "Hello world!"
-      ]
+      "shortResult": ["Hello world!"]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[say_hello].json
+++ b/tests/expected_traces/test_all_primer_recipes[say_hello].json
@@ -4,13 +4,17 @@
       "args": {},
       "name": "say_hello",
       "parent": 0,
-      "shortArgs": ["()"]
+      "shortArgs": [
+        "()"
+      ]
     }
   },
   {
     "1": {
       "result": "Hello world!",
-      "shortResult": ["Hello world!"]
+      "shortResult": [
+        "Hello world!"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[search].json
+++ b/tests/expected_traces/test_all_primer_recipes[search].json
@@ -6,9 +6,7 @@
       },
       "name": "search",
       "parent": 0,
-      "shortArgs": [
-        "Who is the president of the United..."
-      ]
+      "shortArgs": ["Who is the president of the United..."]
     }
   },
   {
@@ -16,9 +14,7 @@
       "result": {
         "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
       },
-      "shortResult": [
-        "Invalid API key. Your API key shoul..."
-      ]
+      "shortResult": ["Invalid API key. Your API key shoul..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[search].json
+++ b/tests/expected_traces/test_all_primer_recipes[search].json
@@ -1,0 +1,24 @@
+[
+  {
+    "1": {
+      "args": {
+        "query": "Who is the president of the United States?"
+      },
+      "name": "search",
+      "parent": 0,
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": {
+        "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
+      },
+      "shortResult": [
+        "Invalid API key. Your API key shoul..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[search].json
+++ b/tests/expected_traces/test_all_primer_recipes[search].json
@@ -6,7 +6,9 @@
       },
       "name": "search",
       "parent": 0,
-      "shortArgs": ["Who is the president of the United..."]
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
     }
   },
   {
@@ -14,7 +16,9 @@
       "result": {
         "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
       },
-      "shortResult": ["Invalid API key. Your API key shoul..."]
+      "shortResult": [
+        "Invalid API key. Your API key shoul..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[search_string].json
+++ b/tests/expected_traces/test_all_primer_recipes[search_string].json
@@ -6,7 +6,9 @@
       },
       "name": "search_string",
       "parent": 0,
-      "shortArgs": ["Who is the president of the United..."]
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
     }
   },
   {
@@ -16,7 +18,9 @@
       },
       "name": "search",
       "parent": 1,
-      "shortArgs": ["Who is the president of the United..."]
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
     }
   },
   {
@@ -24,13 +28,17 @@
       "result": {
         "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
       },
-      "shortResult": ["Invalid API key. Your API key shoul..."]
+      "shortResult": [
+        "Invalid API key. Your API key shoul..."
+      ]
     }
   },
   {
     "1": {
       "result": "No results found",
-      "shortResult": ["No results found"]
+      "shortResult": [
+        "No results found"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[search_string].json
+++ b/tests/expected_traces/test_all_primer_recipes[search_string].json
@@ -1,0 +1,44 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "Who is the president of the United States?"
+      },
+      "name": "search_string",
+      "parent": 0,
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "query": "Who is the president of the United States?"
+      },
+      "name": "search",
+      "parent": 1,
+      "shortArgs": [
+        "Who is the president of the United..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": {
+        "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
+      },
+      "shortResult": [
+        "Invalid API key. Your API key shoul..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "No results found",
+      "shortResult": [
+        "No results found"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[search_string].json
+++ b/tests/expected_traces/test_all_primer_recipes[search_string].json
@@ -6,9 +6,7 @@
       },
       "name": "search_string",
       "parent": 0,
-      "shortArgs": [
-        "Who is the president of the United..."
-      ]
+      "shortArgs": ["Who is the president of the United..."]
     }
   },
   {
@@ -18,9 +16,7 @@
       },
       "name": "search",
       "parent": 1,
-      "shortArgs": [
-        "Who is the president of the United..."
-      ]
+      "shortArgs": ["Who is the president of the United..."]
     }
   },
   {
@@ -28,17 +24,13 @@
       "result": {
         "error": "Invalid API key. Your API key should be here: https://serpapi.com/manage-api-key"
       },
-      "shortResult": [
-        "Invalid API key. Your API key shoul..."
-      ]
+      "shortResult": ["Invalid API key. Your API key shoul..."]
     }
   },
   {
     "1": {
       "result": "No results found",
-      "shortResult": [
-        "No results found"
-      ]
+      "shortResult": ["No results found"]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[sequential_action].json
+++ b/tests/expected_traces/test_all_primer_recipes[sequential_action].json
@@ -7,9 +7,7 @@
       },
       "name": "sequential_action",
       "parent": 0,
-      "shortArgs": [
-        "How far would all the film frames t..."
-      ]
+      "shortArgs": ["How far would all the film frames t..."]
     }
   },
   {
@@ -20,18 +18,13 @@
       },
       "name": "is_info_sufficient",
       "parent": 1,
-      "shortArgs": [
-        "How far would all the film frames t..."
-      ]
+      "shortArgs": ["How far would all the film frames t..."]
     }
   },
   {
     "3": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -61,9 +54,7 @@
       "cls": "FakeAgent",
       "name": "classify",
       "parent": 2,
-      "shortArgs": [
-        "render_context(question, log)"
-      ]
+      "shortArgs": ["render_context(question, log)"]
     }
   },
   {
@@ -75,17 +66,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.7252623521653822"
-      ]
+      "shortResult": ["0.7252623521653822"]
     }
   },
   {
     "2": {
       "result": true,
-      "shortResult": [
-        "True"
-      ]
+      "shortResult": ["True"]
     }
   },
   {
@@ -96,9 +83,7 @@
       },
       "name": "answer_directly",
       "parent": 1,
-      "shortArgs": [
-        "How far would all the film frames t..."
-      ]
+      "shortArgs": ["How far would all the film frames t..."]
     }
   },
   {
@@ -141,33 +126,25 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 4,
-      "shortArgs": [
-        "render_context(question, log)"
-      ]
+      "shortArgs": ["render_context(question, log)"]
     }
   },
   {
     "5": {
       "result": "Option million hope break another station.",
-      "shortResult": [
-        "Option million hope break another s..."
-      ]
+      "shortResult": ["Option million hope break another s..."]
     }
   },
   {
     "4": {
       "result": "Option million hope break another station.",
-      "shortResult": [
-        "Option million hope break another s..."
-      ]
+      "shortResult": ["Option million hope break another s..."]
     }
   },
   {
     "1": {
       "result": "Option million hope break another station.",
-      "shortResult": [
-        "Option million hope break another s..."
-      ]
+      "shortResult": ["Option million hope break another s..."]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[sequential_action].json
+++ b/tests/expected_traces/test_all_primer_recipes[sequential_action].json
@@ -1,0 +1,173 @@
+[
+  {
+    "1": {
+      "args": {
+        "max_actions": 3,
+        "question": "How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?"
+      },
+      "name": "sequential_action",
+      "parent": 0,
+      "shortArgs": [
+        "How far would all the film frames t..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "log": [],
+        "question": "How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?"
+      },
+      "name": "is_info_sufficient",
+      "parent": 1,
+      "shortArgs": [
+        "How far would all the film frames t..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            {
+              "formatted": "The question you want to answer: \"How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?\"",
+              "source": "render_context(question, log)",
+              "value": {
+                "__fstring__": [
+                  "The question you want to answer: \"",
+                  {
+                    "formatted": "How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?",
+                    "source": "question",
+                    "value": "How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?"
+                  },
+                  "\""
+                ]
+              }
+            },
+            "\n\nQ: Do you have enough information to correctly answer the question? Say \"A: Yes\" or \"A: No\"\nA:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 2,
+      "shortArgs": [
+        "render_context(question, log)"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [
+        {
+          " No": 0.2747376478346178,
+          " Yes": 0.7252623521653822
+        },
+        null
+      ],
+      "shortResult": [
+        "0.7252623521653822"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": true,
+      "shortResult": [
+        "True"
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "log": [],
+        "question": "How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?"
+      },
+      "name": "answer_directly",
+      "parent": 1,
+      "shortArgs": [
+        "How far would all the film frames t..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "default": "",
+        "max_tokens": 256,
+        "prompt": {
+          "__fstring__": [
+            {
+              "formatted": "The question you want to answer: \"How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?\"",
+              "source": "render_context(question, log)",
+              "value": {
+                "__fstring__": [
+                  "The question you want to answer: \"",
+                  {
+                    "formatted": "How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?",
+                    "source": "question",
+                    "value": "How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?"
+                  },
+                  "\""
+                ]
+              }
+            },
+            "\n\nQ: ",
+            {
+              "formatted": "How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?",
+              "source": "question",
+              "value": "How far would all the film frames that make up the 400-plus episodes of The Simpsons stretch?"
+            },
+            "\nA:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "stop": null,
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "complete",
+      "parent": 4,
+      "shortArgs": [
+        "render_context(question, log)"
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": "Option million hope break another station.",
+      "shortResult": [
+        "Option million hope break another s..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": "Option million hope break another station.",
+      "shortResult": [
+        "Option million hope break another s..."
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": "Option million hope break another station.",
+      "shortResult": [
+        "Option million hope break another s..."
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[sequential_action].json
+++ b/tests/expected_traces/test_all_primer_recipes[sequential_action].json
@@ -7,7 +7,9 @@
       },
       "name": "sequential_action",
       "parent": 0,
-      "shortArgs": ["How far would all the film frames t..."]
+      "shortArgs": [
+        "How far would all the film frames t..."
+      ]
     }
   },
   {
@@ -18,13 +20,18 @@
       },
       "name": "is_info_sufficient",
       "parent": 1,
-      "shortArgs": ["How far would all the film frames t..."]
+      "shortArgs": [
+        "How far would all the film frames t..."
+      ]
     }
   },
   {
     "3": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -54,7 +61,9 @@
       "cls": "FakeAgent",
       "name": "classify",
       "parent": 2,
-      "shortArgs": ["render_context(question, log)"]
+      "shortArgs": [
+        "render_context(question, log)"
+      ]
     }
   },
   {
@@ -66,13 +75,17 @@
         },
         null
       ],
-      "shortResult": ["0.7252623521653822"]
+      "shortResult": [
+        "0.7252623521653822"
+      ]
     }
   },
   {
     "2": {
       "result": true,
-      "shortResult": ["True"]
+      "shortResult": [
+        "True"
+      ]
     }
   },
   {
@@ -83,7 +96,9 @@
       },
       "name": "answer_directly",
       "parent": 1,
-      "shortArgs": ["How far would all the film frames t..."]
+      "shortArgs": [
+        "How far would all the film frames t..."
+      ]
     }
   },
   {
@@ -126,25 +141,33 @@
       "cls": "FakeAgent",
       "name": "complete",
       "parent": 4,
-      "shortArgs": ["render_context(question, log)"]
+      "shortArgs": [
+        "render_context(question, log)"
+      ]
     }
   },
   {
     "5": {
       "result": "Option million hope break another station.",
-      "shortResult": ["Option million hope break another s..."]
+      "shortResult": [
+        "Option million hope break another s..."
+      ]
     }
   },
   {
     "4": {
       "result": "Option million hope break another station.",
-      "shortResult": ["Option million hope break another s..."]
+      "shortResult": [
+        "Option million hope break another s..."
+      ]
     }
   },
   {
     "1": {
       "result": "Option million hope break another station.",
-      "shortResult": ["Option million hope break another s..."]
+      "shortResult": [
+        "Option million hope break another s..."
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[verify_answer0].json
+++ b/tests/expected_traces/test_all_primer_recipes[verify_answer0].json
@@ -12,7 +12,9 @@
       },
       "name": "verify_answer",
       "parent": 0,
-      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
     }
   },
   {
@@ -28,13 +30,18 @@
       },
       "name": "check_step",
       "parent": 1,
-      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
     }
   },
   {
     "3": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -73,7 +80,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -99,7 +108,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -125,7 +136,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -184,19 +197,25 @@
         },
         null
       ],
-      "shortResult": ["0.39836915192886757"]
+      "shortResult": [
+        "0.39836915192886757"
+      ]
     }
   },
   {
     "2": {
       "result": 0.39836915192886757,
-      "shortResult": ["0.39836915192886757"]
+      "shortResult": [
+        "0.39836915192886757"
+      ]
     }
   },
   {
     "1": {
       "result": 0.39836915192886757,
-      "shortResult": ["0.39836915192886757"]
+      "shortResult": [
+        "0.39836915192886757"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[verify_answer0].json
+++ b/tests/expected_traces/test_all_primer_recipes[verify_answer0].json
@@ -1,0 +1,221 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+        "steps": [
+          "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+          "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+          "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+          "So, the final answer is 6 cookies per person."
+        ]
+      },
+      "name": "verify_answer",
+      "parent": 0,
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "question": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+        "steps": [
+          "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+          "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+          "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+          "So, the final answer is 6 cookies per person."
+        ]
+      },
+      "name": "check_step",
+      "parent": 1,
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Consider this question: \"",
+            {
+              "formatted": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+              "source": "question",
+              "value": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?"
+            },
+            "\"\n\nHere are the first few steps of an answer:\n\n",
+            {
+              "formatted": "1. Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies\n2. There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies\n3. She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies\n4. So, the final answer is 6 cookies per person.",
+              "source": "render_steps(steps)",
+              "value": {
+                "__fstring__": [
+                  {
+                    "formatted": "1. Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[0]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "1",
+                          "source": "i",
+                          "value": 1
+                        },
+                        ". ",
+                        {
+                          "formatted": "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+                          "source": "step",
+                          "value": "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "2. There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[1]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "2",
+                          "source": "i",
+                          "value": 2
+                        },
+                        ". ",
+                        {
+                          "formatted": "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+                          "source": "step",
+                          "value": "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "3. She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[2]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "3",
+                          "source": "i",
+                          "value": 3
+                        },
+                        ". ",
+                        {
+                          "formatted": "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+                          "source": "step",
+                          "value": "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "4. So, the final answer is 6 cookies per person.",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[3]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "4",
+                          "source": "i",
+                          "value": 4
+                        },
+                        ". ",
+                        {
+                          "formatted": "So, the final answer is 6 cookies per person.",
+                          "source": "step",
+                          "value": "So, the final answer is 6 cookies per person."
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "\n\nQ: Is step ",
+            {
+              "formatted": "4",
+              "source": "len(steps)",
+              "value": 4
+            },
+            " correct, assuming that the previous steps are correct? Say \"A: Yes\" or \"A: No\".\nA:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 2,
+      "shortArgs": [
+        "Consider this question: \"",
+        "\"\n\nHere are the first few steps of...",
+        "\n\nQ: Is step ",
+        "..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": [
+        {
+          " No": 0.6016308480711324,
+          " Yes": 0.39836915192886757
+        },
+        null
+      ],
+      "shortResult": [
+        "0.39836915192886757"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": 0.39836915192886757,
+      "shortResult": [
+        "0.39836915192886757"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": 0.39836915192886757,
+      "shortResult": [
+        "0.39836915192886757"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[verify_answer0].json
+++ b/tests/expected_traces/test_all_primer_recipes[verify_answer0].json
@@ -12,9 +12,7 @@
       },
       "name": "verify_answer",
       "parent": 0,
-      "shortArgs": [
-        "Beth bakes 4x 2 dozen batches of co..."
-      ]
+      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
     }
   },
   {
@@ -30,18 +28,13 @@
       },
       "name": "check_step",
       "parent": 1,
-      "shortArgs": [
-        "Beth bakes 4x 2 dozen batches of co..."
-      ]
+      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
     }
   },
   {
     "3": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -80,9 +73,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -108,9 +99,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -136,9 +125,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -197,25 +184,19 @@
         },
         null
       ],
-      "shortResult": [
-        "0.39836915192886757"
-      ]
+      "shortResult": ["0.39836915192886757"]
     }
   },
   {
     "2": {
       "result": 0.39836915192886757,
-      "shortResult": [
-        "0.39836915192886757"
-      ]
+      "shortResult": ["0.39836915192886757"]
     }
   },
   {
     "1": {
       "result": 0.39836915192886757,
-      "shortResult": [
-        "0.39836915192886757"
-      ]
+      "shortResult": ["0.39836915192886757"]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[verify_answer1].json
+++ b/tests/expected_traces/test_all_primer_recipes[verify_answer1].json
@@ -1,0 +1,643 @@
+[
+  {
+    "1": {
+      "args": {
+        "question": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+        "steps": [
+          "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+          "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+          "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+          "So, the final answer is 6 cookies per person."
+        ]
+      },
+      "name": "verify_answer",
+      "parent": 0,
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "question": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+        "steps": [
+          "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"
+        ]
+      },
+      "name": "check_step",
+      "parent": 1,
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
+    }
+  },
+  {
+    "3": {
+      "args": {
+        "question": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+        "steps": [
+          "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+          "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies"
+        ]
+      },
+      "name": "check_step",
+      "parent": 1,
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
+    }
+  },
+  {
+    "4": {
+      "args": {
+        "question": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+        "steps": [
+          "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+          "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+          "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies"
+        ]
+      },
+      "name": "check_step",
+      "parent": 1,
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
+    }
+  },
+  {
+    "5": {
+      "args": {
+        "question": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+        "steps": [
+          "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+          "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+          "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+          "So, the final answer is 6 cookies per person."
+        ]
+      },
+      "name": "check_step",
+      "parent": 1,
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
+    }
+  },
+  {
+    "6": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Consider this question: \"",
+            {
+              "formatted": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+              "source": "question",
+              "value": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?"
+            },
+            "\"\n\nHere are the first few steps of an answer:\n\n",
+            {
+              "formatted": "1. Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+              "source": "render_steps(steps)",
+              "value": {
+                "__fstring__": [
+                  {
+                    "formatted": "1. Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[0]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "1",
+                          "source": "i",
+                          "value": 1
+                        },
+                        ". ",
+                        {
+                          "formatted": "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+                          "source": "step",
+                          "value": "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "\n\nQ: Is step ",
+            {
+              "formatted": "1",
+              "source": "len(steps)",
+              "value": 1
+            },
+            " correct, assuming that the previous steps are correct? Say \"A: Yes\" or \"A: No\".\nA:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 2,
+      "shortArgs": [
+        "Consider this question: \"",
+        "\"\n\nHere are the first few steps of...",
+        "\n\nQ: Is step ",
+        "..."
+      ]
+    }
+  },
+  {
+    "6": {
+      "result": [
+        {
+          " No": 0.1626368830884087,
+          " Yes": 0.8373631169115912
+        },
+        null
+      ],
+      "shortResult": [
+        "0.8373631169115912"
+      ]
+    }
+  },
+  {
+    "7": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Consider this question: \"",
+            {
+              "formatted": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+              "source": "question",
+              "value": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?"
+            },
+            "\"\n\nHere are the first few steps of an answer:\n\n",
+            {
+              "formatted": "1. Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies\n2. There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+              "source": "render_steps(steps)",
+              "value": {
+                "__fstring__": [
+                  {
+                    "formatted": "1. Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[0]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "1",
+                          "source": "i",
+                          "value": 1
+                        },
+                        ". ",
+                        {
+                          "formatted": "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+                          "source": "step",
+                          "value": "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "2. There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[1]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "2",
+                          "source": "i",
+                          "value": 2
+                        },
+                        ". ",
+                        {
+                          "formatted": "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+                          "source": "step",
+                          "value": "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "\n\nQ: Is step ",
+            {
+              "formatted": "2",
+              "source": "len(steps)",
+              "value": 2
+            },
+            " correct, assuming that the previous steps are correct? Say \"A: Yes\" or \"A: No\".\nA:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 3,
+      "shortArgs": [
+        "Consider this question: \"",
+        "\"\n\nHere are the first few steps of...",
+        "\n\nQ: Is step ",
+        "..."
+      ]
+    }
+  },
+  {
+    "7": {
+      "result": [
+        {
+          " No": 0.41064257347452415,
+          " Yes": 0.5893574265254758
+        },
+        null
+      ],
+      "shortResult": [
+        "0.5893574265254758"
+      ]
+    }
+  },
+  {
+    "8": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Consider this question: \"",
+            {
+              "formatted": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+              "source": "question",
+              "value": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?"
+            },
+            "\"\n\nHere are the first few steps of an answer:\n\n",
+            {
+              "formatted": "1. Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies\n2. There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies\n3. She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+              "source": "render_steps(steps)",
+              "value": {
+                "__fstring__": [
+                  {
+                    "formatted": "1. Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[0]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "1",
+                          "source": "i",
+                          "value": 1
+                        },
+                        ". ",
+                        {
+                          "formatted": "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+                          "source": "step",
+                          "value": "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "2. There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[1]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "2",
+                          "source": "i",
+                          "value": 2
+                        },
+                        ". ",
+                        {
+                          "formatted": "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+                          "source": "step",
+                          "value": "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "3. She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[2]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "3",
+                          "source": "i",
+                          "value": 3
+                        },
+                        ". ",
+                        {
+                          "formatted": "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+                          "source": "step",
+                          "value": "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "\n\nQ: Is step ",
+            {
+              "formatted": "3",
+              "source": "len(steps)",
+              "value": 3
+            },
+            " correct, assuming that the previous steps are correct? Say \"A: Yes\" or \"A: No\".\nA:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 4,
+      "shortArgs": [
+        "Consider this question: \"",
+        "\"\n\nHere are the first few steps of...",
+        "\n\nQ: Is step ",
+        "..."
+      ]
+    }
+  },
+  {
+    "8": {
+      "result": [
+        {
+          " No": 0.6934821315117362,
+          " Yes": 0.3065178684882638
+        },
+        null
+      ],
+      "shortResult": [
+        "0.3065178684882638"
+      ]
+    }
+  },
+  {
+    "9": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Consider this question: \"",
+            {
+              "formatted": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
+              "source": "question",
+              "value": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?"
+            },
+            "\"\n\nHere are the first few steps of an answer:\n\n",
+            {
+              "formatted": "1. Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies\n2. There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies\n3. She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies\n4. So, the final answer is 6 cookies per person.",
+              "source": "render_steps(steps)",
+              "value": {
+                "__fstring__": [
+                  {
+                    "formatted": "1. Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[0]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "1",
+                          "source": "i",
+                          "value": 1
+                        },
+                        ". ",
+                        {
+                          "formatted": "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies",
+                          "source": "step",
+                          "value": "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "2. There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[1]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "2",
+                          "source": "i",
+                          "value": 2
+                        },
+                        ". ",
+                        {
+                          "formatted": "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies",
+                          "source": "step",
+                          "value": "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "3. She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[2]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "3",
+                          "source": "i",
+                          "value": 3
+                        },
+                        ". ",
+                        {
+                          "formatted": "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies",
+                          "source": "step",
+                          "value": "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "\n",
+                    "source": "F(\"\\n\")",
+                    "value": {
+                      "__fstring__": [
+                        "\n"
+                      ]
+                    }
+                  },
+                  {
+                    "formatted": "4. So, the final answer is 6 cookies per person.",
+                    "source": "list((F(f\"{i}. {step}\") for (i, step) in enumerate(steps, start=1)))[3]",
+                    "value": {
+                      "__fstring__": [
+                        {
+                          "formatted": "4",
+                          "source": "i",
+                          "value": 4
+                        },
+                        ". ",
+                        {
+                          "formatted": "So, the final answer is 6 cookies per person.",
+                          "source": "step",
+                          "value": "So, the final answer is 6 cookies per person."
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            "\n\nQ: Is step ",
+            {
+              "formatted": "4",
+              "source": "len(steps)",
+              "value": 4
+            },
+            " correct, assuming that the previous steps are correct? Say \"A: Yes\" or \"A: No\".\nA:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 5,
+      "shortArgs": [
+        "Consider this question: \"",
+        "\"\n\nHere are the first few steps of...",
+        "\n\nQ: Is step ",
+        "..."
+      ]
+    }
+  },
+  {
+    "9": {
+      "result": [
+        {
+          " No": 0.38345733438710905,
+          " Yes": 0.616542665612891
+        },
+        null
+      ],
+      "shortResult": [
+        "0.616542665612891"
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": 0.8373631169115912,
+      "shortResult": [
+        "0.8373631169115912"
+      ]
+    }
+  },
+  {
+    "3": {
+      "result": 0.5893574265254758,
+      "shortResult": [
+        "0.5893574265254758"
+      ]
+    }
+  },
+  {
+    "4": {
+      "result": 0.3065178684882638,
+      "shortResult": [
+        "0.3065178684882638"
+      ]
+    }
+  },
+  {
+    "5": {
+      "result": 0.616542665612891,
+      "shortResult": [
+        "0.616542665612891"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": [
+        [
+          0.8373631169115912,
+          "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"
+        ],
+        [
+          0.5893574265254758,
+          "There are 12 cookies in a dozen and she makes 8 dozen cookies for a total of 12*8 = 96 cookies"
+        ],
+        [
+          0.3065178684882638,
+          "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies"
+        ],
+        [
+          0.616542665612891,
+          "So, the final answer is 6 cookies per person."
+        ]
+      ],
+      "shortResult": [
+        "0.8373631169115912"
+      ]
+    }
+  }
+]

--- a/tests/expected_traces/test_all_primer_recipes[verify_answer1].json
+++ b/tests/expected_traces/test_all_primer_recipes[verify_answer1].json
@@ -12,18 +12,24 @@
       },
       "name": "verify_answer",
       "parent": 0,
-      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
     }
   },
   {
     "2": {
       "args": {
         "question": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
-        "steps": ["Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"]
+        "steps": [
+          "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"
+        ]
       },
       "name": "check_step",
       "parent": 1,
-      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
     }
   },
   {
@@ -37,7 +43,9 @@
       },
       "name": "check_step",
       "parent": 1,
-      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
     }
   },
   {
@@ -52,7 +60,9 @@
       },
       "name": "check_step",
       "parent": 1,
-      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
     }
   },
   {
@@ -68,13 +78,18 @@
       },
       "name": "check_step",
       "parent": 1,
-      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
+      "shortArgs": [
+        "Beth bakes 4x 2 dozen batches of co..."
+      ]
     }
   },
   {
     "6": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -146,13 +161,18 @@
         },
         null
       ],
-      "shortResult": ["0.8373631169115912"]
+      "shortResult": [
+        "0.8373631169115912"
+      ]
     }
   },
   {
     "7": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -191,7 +211,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -250,13 +272,18 @@
         },
         null
       ],
-      "shortResult": ["0.5893574265254758"]
+      "shortResult": [
+        "0.5893574265254758"
+      ]
     }
   },
   {
     "8": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -295,7 +322,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -321,7 +350,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -380,13 +411,18 @@
         },
         null
       ],
-      "shortResult": ["0.3065178684882638"]
+      "shortResult": [
+        "0.3065178684882638"
+      ]
     }
   },
   {
     "9": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -425,7 +461,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -451,7 +489,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -477,7 +517,9 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": ["\n"]
+                      "__fstring__": [
+                        "\n"
+                      ]
                     }
                   },
                   {
@@ -536,31 +578,41 @@
         },
         null
       ],
-      "shortResult": ["0.616542665612891"]
+      "shortResult": [
+        "0.616542665612891"
+      ]
     }
   },
   {
     "2": {
       "result": 0.8373631169115912,
-      "shortResult": ["0.8373631169115912"]
+      "shortResult": [
+        "0.8373631169115912"
+      ]
     }
   },
   {
     "3": {
       "result": 0.5893574265254758,
-      "shortResult": ["0.5893574265254758"]
+      "shortResult": [
+        "0.5893574265254758"
+      ]
     }
   },
   {
     "4": {
       "result": 0.3065178684882638,
-      "shortResult": ["0.3065178684882638"]
+      "shortResult": [
+        "0.3065178684882638"
+      ]
     }
   },
   {
     "5": {
       "result": 0.616542665612891,
-      "shortResult": ["0.616542665612891"]
+      "shortResult": [
+        "0.616542665612891"
+      ]
     }
   },
   {
@@ -578,9 +630,14 @@
           0.3065178684882638,
           "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies"
         ],
-        [0.616542665612891, "So, the final answer is 6 cookies per person."]
+        [
+          0.616542665612891,
+          "So, the final answer is 6 cookies per person."
+        ]
       ],
-      "shortResult": ["0.8373631169115912"]
+      "shortResult": [
+        "0.8373631169115912"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[verify_answer1].json
+++ b/tests/expected_traces/test_all_primer_recipes[verify_answer1].json
@@ -12,24 +12,18 @@
       },
       "name": "verify_answer",
       "parent": 0,
-      "shortArgs": [
-        "Beth bakes 4x 2 dozen batches of co..."
-      ]
+      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
     }
   },
   {
     "2": {
       "args": {
         "question": "Beth bakes 4x 2 dozen batches of cookies in a week. If these cookies are shared amongst 16 people equally, how many cookies does each person consume?",
-        "steps": [
-          "Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"
-        ]
+        "steps": ["Beth bakes 4x 2 dozen batches of cookies for a total of 4*2 = 8 dozen cookies"]
       },
       "name": "check_step",
       "parent": 1,
-      "shortArgs": [
-        "Beth bakes 4x 2 dozen batches of co..."
-      ]
+      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
     }
   },
   {
@@ -43,9 +37,7 @@
       },
       "name": "check_step",
       "parent": 1,
-      "shortArgs": [
-        "Beth bakes 4x 2 dozen batches of co..."
-      ]
+      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
     }
   },
   {
@@ -60,9 +52,7 @@
       },
       "name": "check_step",
       "parent": 1,
-      "shortArgs": [
-        "Beth bakes 4x 2 dozen batches of co..."
-      ]
+      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
     }
   },
   {
@@ -78,18 +68,13 @@
       },
       "name": "check_step",
       "parent": 1,
-      "shortArgs": [
-        "Beth bakes 4x 2 dozen batches of co..."
-      ]
+      "shortArgs": ["Beth bakes 4x 2 dozen batches of co..."]
     }
   },
   {
     "6": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -161,18 +146,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.8373631169115912"
-      ]
+      "shortResult": ["0.8373631169115912"]
     }
   },
   {
     "7": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -211,9 +191,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -272,18 +250,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.5893574265254758"
-      ]
+      "shortResult": ["0.5893574265254758"]
     }
   },
   {
     "8": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -322,9 +295,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -350,9 +321,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -411,18 +380,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.3065178684882638"
-      ]
+      "shortResult": ["0.3065178684882638"]
     }
   },
   {
     "9": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -461,9 +425,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -489,9 +451,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -517,9 +477,7 @@
                     "formatted": "\n",
                     "source": "F(\"\\n\")",
                     "value": {
-                      "__fstring__": [
-                        "\n"
-                      ]
+                      "__fstring__": ["\n"]
                     }
                   },
                   {
@@ -578,41 +536,31 @@
         },
         null
       ],
-      "shortResult": [
-        "0.616542665612891"
-      ]
+      "shortResult": ["0.616542665612891"]
     }
   },
   {
     "2": {
       "result": 0.8373631169115912,
-      "shortResult": [
-        "0.8373631169115912"
-      ]
+      "shortResult": ["0.8373631169115912"]
     }
   },
   {
     "3": {
       "result": 0.5893574265254758,
-      "shortResult": [
-        "0.5893574265254758"
-      ]
+      "shortResult": ["0.5893574265254758"]
     }
   },
   {
     "4": {
       "result": 0.3065178684882638,
-      "shortResult": [
-        "0.3065178684882638"
-      ]
+      "shortResult": ["0.3065178684882638"]
     }
   },
   {
     "5": {
       "result": 0.616542665612891,
-      "shortResult": [
-        "0.616542665612891"
-      ]
+      "shortResult": ["0.616542665612891"]
     }
   },
   {
@@ -630,14 +578,9 @@
           0.3065178684882638,
           "She splits the 96 cookies equally amongst 16 people so they each eat 96/16 = 6 cookies"
         ],
-        [
-          0.616542665612891,
-          "So, the final answer is 6 cookies per person."
-        ]
+        [0.616542665612891, "So, the final answer is 6 cookies per person."]
       ],
-      "shortResult": [
-        "0.8373631169115912"
-      ]
+      "shortResult": ["0.8373631169115912"]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[verify_answer2].json
+++ b/tests/expected_traces/test_all_primer_recipes[verify_answer2].json
@@ -7,13 +7,18 @@
       },
       "name": "verify_answer",
       "parent": 0,
-      "shortArgs": ["Stay I price room least experience."]
+      "shortArgs": [
+        "Stay I price room least experience."
+      ]
     }
   },
   {
     "2": {
       "args": {
-        "choices": [" Yes", " No"],
+        "choices": [
+          " Yes",
+          " No"
+        ],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -56,13 +61,17 @@
         },
         null
       ],
-      "shortResult": ["0.5191504877112162"]
+      "shortResult": [
+        "0.5191504877112162"
+      ]
     }
   },
   {
     "1": {
       "result": 0.5191504877112162,
-      "shortResult": ["0.5191504877112162"]
+      "shortResult": [
+        "0.5191504877112162"
+      ]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[verify_answer2].json
+++ b/tests/expected_traces/test_all_primer_recipes[verify_answer2].json
@@ -7,18 +7,13 @@
       },
       "name": "verify_answer",
       "parent": 0,
-      "shortArgs": [
-        "Stay I price room least experience."
-      ]
+      "shortArgs": ["Stay I price room least experience."]
     }
   },
   {
     "2": {
       "args": {
-        "choices": [
-          " Yes",
-          " No"
-        ],
+        "choices": [" Yes", " No"],
         "default": null,
         "prompt": {
           "__fstring__": [
@@ -61,17 +56,13 @@
         },
         null
       ],
-      "shortResult": [
-        "0.5191504877112162"
-      ]
+      "shortResult": ["0.5191504877112162"]
     }
   },
   {
     "1": {
       "result": 0.5191504877112162,
-      "shortResult": [
-        "0.5191504877112162"
-      ]
+      "shortResult": ["0.5191504877112162"]
     }
   }
 ]

--- a/tests/expected_traces/test_all_primer_recipes[verify_answer2].json
+++ b/tests/expected_traces/test_all_primer_recipes[verify_answer2].json
@@ -1,0 +1,77 @@
+[
+  {
+    "1": {
+      "args": {
+        "answer": "Far treat early American.",
+        "question": "Stay I price room least experience."
+      },
+      "name": "verify_answer",
+      "parent": 0,
+      "shortArgs": [
+        "Stay I price room least experience."
+      ]
+    }
+  },
+  {
+    "2": {
+      "args": {
+        "choices": [
+          " Yes",
+          " No"
+        ],
+        "default": null,
+        "prompt": {
+          "__fstring__": [
+            "Consider this question: \"",
+            {
+              "formatted": "Stay I price room least experience.",
+              "source": "question",
+              "value": "Stay I price room least experience."
+            },
+            "\"\n\nPotential answer: \"",
+            {
+              "formatted": "Far treat early American.",
+              "source": "answer",
+              "value": "Far treat early American."
+            },
+            "\"\n\nQ: Is the potential answer above correct? Say \"A: Yes\" or \"A: No\".\nA:"
+          ]
+        },
+        "self": {
+          "class_name": "FakeAgent"
+        },
+        "verbose": false
+      },
+      "cls": "FakeAgent",
+      "name": "classify",
+      "parent": 1,
+      "shortArgs": [
+        "Consider this question: \"",
+        "\"\n\nPotential answer: \"",
+        "\"\n\nQ: Is the potential answer above..."
+      ]
+    }
+  },
+  {
+    "2": {
+      "result": [
+        {
+          " No": 0.48084951228878386,
+          " Yes": 0.5191504877112162
+        },
+        null
+      ],
+      "shortResult": [
+        "0.5191504877112162"
+      ]
+    }
+  },
+  {
+    "1": {
+      "result": 0.5191504877112162,
+      "shortResult": [
+        "0.5191504877112162"
+      ]
+    }
+  }
+]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ import pytest
 from ice.recipe import Recipe
 from ice.recipes import get_recipe_classes
 from main import main_cli
-
+from tests.test_regression import check_trace
 
 nest_asyncio.apply()
 
@@ -45,11 +45,12 @@ no_paper_recipe_classes = [
 )
 @pytest.mark.anyio
 async def test_paper_recipes(recipe_name: str):
-    main_cli(
-        mode="test",
-        input_files=["./papers/keenan-2018-tiny.txt"],
-        recipe_name=recipe_name,
-    )
+    with check_trace(recipe_name):
+        main_cli(
+            mode="test",
+            input_files=["./papers/keenan-2018-tiny.txt"],
+            recipe_name=recipe_name,
+        )
 
 
 @pytest.mark.parametrize(
@@ -58,7 +59,8 @@ async def test_paper_recipes(recipe_name: str):
 )
 @pytest.mark.anyio
 async def test_no_paper_recipes(recipe_name: str):
-    main_cli(
-        mode="test",
-        recipe_name=recipe_name,
-    )
+    with check_trace(recipe_name):
+        main_cli(
+            mode="test",
+            recipe_name=recipe_name,
+        )

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,59 @@
+"""
+This module doesn't contain any tests directly.
+The filename just starts with test_ so that pytest rewrites asserts.
+Call check_trace() in another test after calling a traced function.
+"""
+
+import json
+import os
+import random
+from contextlib import contextmanager
+from pathlib import Path
+
+from faker import Faker
+
+from ice.trace import trace_var
+from ice.trace_reader import TraceReader
+
+
+def normalized_trace_events(trace_id: str):
+    reader = TraceReader(trace_id)
+    for event in reader.events_with_block_values():
+        [[_call_id, data]] = event.items()
+        if "start" in data:
+            assert isinstance(data.pop("start"), int)
+            assert isinstance(data.pop("func"), dict)
+        elif "end" in data:
+            assert isinstance(data.pop("end"), int)
+
+        yield event
+
+
+@contextmanager
+def check_trace(name: str):
+    """
+    Check that the most recent trace matches the expected trace on disk.
+    `name` is the filename under the expected_traces folder.
+    Set the environment variable FIX_TESTS=1 to update the expected trace.
+    """
+    Faker.seed(name)
+    random.seed(name)
+
+    yield
+
+    trc = trace_var.get()
+    assert trc
+    actual = list(normalized_trace_events(trc.id))
+    assert actual
+    path = Path(__file__).parent / "expected_traces" / f"{name}.json"
+    if os.environ.get("FIX_TESTS"):
+        json_dump = json.dumps(actual, indent=2, sort_keys=True)
+        if len(json_dump) < 50_000:
+            path.write_text(json_dump)
+        elif path.exists():
+            raise ValueError(
+                f"Trace has become too large: {path} ({len(json_dump)} bytes)"
+            )
+    elif path.exists():
+        expected = json.loads(path.read_text())
+        assert actual == expected

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -3,10 +3,10 @@ This module doesn't contain any tests directly.
 The filename just starts with test_ so that pytest rewrites asserts.
 Call check_trace() in another test after calling a traced function.
 """
-
 import json
 import os
 import random
+
 from contextlib import contextmanager
 from pathlib import Path
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -49,7 +49,7 @@ def check_trace(name: str):
     if os.environ.get("FIX_TESTS"):
         json_dump = json.dumps(actual, indent=2, sort_keys=True)
         if len(json_dump) < 50_000:
-            path.write_text(json_dump)
+            path.write_text(json_dump + "\n")
         elif path.exists():
             raise ValueError(
                 f"Trace has become too large: {path} ({len(json_dump)} bytes)"


### PR DESCRIPTION
Builds on #161, so similarly blocked

Adds a context manager function `check_trace(name)` to be used in tests. This asserts that the trace produced within matches a JSON file. If differences are expected due to intentional changes, run the test(s) with the environment variable `FIX_TESTS=1`.

Things that have been done to make the traces consistently reproducible and have nice git diffs:

- Primer recipes are run in test mode, i.e. using FakeAgent instead of OpenAIAgent. This should make tests faster and cheaper, especially when missing a cache (e.g. in CI), but it may also mean losing some test coverage of OpenAI API code.
- Call IDs have been switched from long random ULIDs to simple incrementing integers.
- Instead of one JSON object per line, the file contains a single prettified JSON array.
- Block values are inlined.
- Function source code and documentation is omitted.