### PR TITLE
Fix passing of exclude argument in Paper.dict

### DIFF
--- a/ice/paper.py
+++ b/ice/paper.py
@@ -177,4 +177,4 @@ class Paper(BaseModel):
         return "\n\n".join(str(p) for p in self.paragraphs)
 
     def dict(self, *args, **kwargs):
-        return super().dict(*args, **kwargs, exclude={"paragraphs"})
+        return super().dict(*args, **{**kwargs, "exclude": {"paragraphs"}})

--- a/ice/paper.py
+++ b/ice/paper.py
@@ -177,4 +177,4 @@ class Paper(BaseModel):
         return "\n\n".join(str(p) for p in self.paragraphs)
 
     def dict(self, *args, **kwargs):
-        return super().dict(*args, **{**kwargs, "exclude": {"paragraphs"}})
+        return super().dict(*args, **(kwargs | {"exclude": {"paragraphs"}}))


### PR DESCRIPTION
I noticed Paper wasn't serializing properly in a particular case. I don't fully understand what exactly was happening, Pydantic was being weird, possibly due to some C-extension code. But an error was being raised by the `exclude` argument being passed multiple times.