### PR TITLE
Fix component remount on dev

### DIFF
--- a/ui/components/TracePage/TracePage.tsx
+++ b/ui/components/TracePage/TracePage.tsx
@@ -175,6 +175,7 @@ const TreeProvider = ({ traceId, children }: { traceId: string; children: ReactN
   const isMounted = useRef(true);
 
   useEffect(() => {
+    isMounted.current = true;
     let timeoutId: ReturnType<typeof setTimeout>;
 
     const poll = async () => {


### PR DESCRIPTION
On dev (but not on prod), TracePage is unmounted and remounted, but isMounted.current stays false and the trace tree never renders. This appears to be due to React.StrictMode, as seen in this other bug on another project: https://github.com/apollographql/apollo-client/issues/6037