### PR TITLE
Explicitly link to the primer on the home page and the trace list page

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you use Windows, you'll need to run ICE inside of [WSL](https://learn.microso
 
 1. Set required secrets in `~/.ought-ice/.env`. See [`.env.example`](https://github.com/oughtinc/ice/blob/main/.env.example) for the format.
 
-1. To learn more, go through [the Primer](https://primer.ought.org/).
+1. Run the Hello World recipe in [the Primer](https://primer.ought.org/) to see the trace rendered.
 
 ## Developing ICE
 

--- a/ui/pages/HomePage.tsx
+++ b/ui/pages/HomePage.tsx
@@ -47,6 +47,9 @@ export default function HomePage() {
         visualizer for compositional language model programs. This page hosts a collection of traces
         that demonstrate programs written in ICE.
       </p>
+      <div className="p-2 pl-0">
+        <Link to="traces/">You can view your own traces here.</Link>
+      </div>
       <RecipeGroup title="Elicit" recipes={elicitRecipes}>
         <p>
           <a href="https://elicit.org/">Elicit</a> is an AI research assistant. The traces below

--- a/ui/pages/TraceListPage.tsx
+++ b/ui/pages/TraceListPage.tsx
@@ -8,7 +8,13 @@ export default function TraceListPage() {
       .then(res => res.json())
       .then(setTraces);
   }, []);
-  return (
+  return traces.length === 0 ? (
+    <div className="m-8 flex-col space-y-4">
+      No traces yet! Create your first one by following the&nbsp;
+      <a href="https://primer.ought.org/chapters/hello-world">Hello World</a>
+      &nbsp;example in the Primer.
+    </div>
+  ) : (
     <div className="m-8 flex flex-col space-y-4">
       {traces.map(traceId => (
         <Link key={traceId} className="font-mono" to={traceId}>

--- a/ui/pages/TraceListPage.tsx
+++ b/ui/pages/TraceListPage.tsx
@@ -9,7 +9,7 @@ export default function TraceListPage() {
       .then(setTraces);
   }, []);
   return traces.length === 0 ? (
-    <div className="m-8 flex-col space-y-4">
+    <div className="m-8">
       No traces yet! Create your first one by following the&nbsp;
       <a href="https://primer.ought.org/chapters/hello-world">Hello World</a>
       &nbsp;example in the Primer.


### PR DESCRIPTION
I didn't realize at first how this was supposed to work, if it was possible for me to run my own queries or not, or if the demo page was the only thing there was. I figure this might make it clearer for people like me.

Just a suggestion. Feel free to ignore :)