### PR TITLE
Allow specifying Elicit search filters

### DIFF
--- a/ice/recipes/elicit/search.py
+++ b/ice/recipes/elicit/search.py
@@ -51,7 +51,7 @@ async def elicit_search(
     endpoint = backend.rstrip("/") + "/lit-review"
 
     log.info(f"Searching Elicit for query: {question}, endpoint: {endpoint}")
-    
+
     all_filters = dict(has_pdf=has_pdf_filter)
 
     if filters is not None:

--- a/ice/recipes/elicit/search.py
+++ b/ice/recipes/elicit/search.py
@@ -52,13 +52,11 @@ async def elicit_search(
 
     log.info(f"Searching Elicit for query: {question}, endpoint: {endpoint}")
 
-    all_filters = dict(has_pdf=has_pdf_filter)
-
-    if filters is not None:
-        all_filters = {**filters, **all_filters}
-
     request_body = make_request_body(
-        query=question, num_papers=num_papers, page=page, filters=all_filters
+        query=question,
+        num_papers=num_papers,
+        page=page,
+        filters=(filters or {}) | dict(has_pdf=has_pdf_filter),
     )
 
     response = send_elicit_request(

--- a/ice/recipes/elicit/search.py
+++ b/ice/recipes/elicit/search.py
@@ -40,6 +40,7 @@ async def elicit_search(
     page: int = 0,
     has_pdf_filter: bool = False,
     backend: str | None = None,
+    filters: dict | None = None,
 ):
     """
     Search Elicit for papers related to a question.
@@ -50,11 +51,14 @@ async def elicit_search(
     endpoint = backend.rstrip("/") + "/lit-review"
 
     log.info(f"Searching Elicit for query: {question}, endpoint: {endpoint}")
+    
+    all_filters = dict(has_pdf=has_pdf_filter)
 
-    filters = dict(has_pdf=has_pdf_filter)
+    if filters is not None:
+        all_filters = {**filters, **all_filters}
 
     request_body = make_request_body(
-        query=question, num_papers=num_papers, page=page, filters=filters
+        query=question, num_papers=num_papers, page=page, filters=all_filters
     )
 
     response = send_elicit_request(


### PR DESCRIPTION
I didn't want this to be a breaking change with existing use of this API, so this handles `has_pdf` separately from the other filters