### PR TITLE
Increase default timeout

### DIFF
--- a/ice/apis/openai.py
+++ b/ice/apis/openai.py
@@ -114,7 +114,7 @@ async def _post(
             f"{OPENAI_BASE_URL}/{endpoint}",
             json=json,
             headers=make_headers(),
-            timeout=timeout or 20,
+            timeout=timeout or 60,
         )
         if response.status_code == 429:
             raise RateLimitError(response)


### PR DESCRIPTION
I considered exposing the param through `openai_complete`, but that would blow everyone's `_post` cache. One of these days we've got to replace `@diskcache` with something more reasonable.