### PR TITLE
Remove build-storybook from package.json

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -48,8 +48,7 @@
     "build": "vite build",
     "dev": "vite",
     "postinstall": "patch-package",
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "storybook": "storybook dev -p 6006"
   },
   "version": "0.0.0"
 }


### PR DESCRIPTION
Talked with @lslunis about this, who confirmed that it was fine for me to remove this script from `package.json`. 

One reason that this is nice is that now you can't run it and accidentally create `ui/storybook-static`, which wasn't covered in `.gitignore`. 

I 'tested' this by confirming that `build-storybook` wasn't mentioned in either the `ice` or `primer` repos. :) 