### PR TITLE
Fix content centering inside CallIconButton

### DIFF
--- a/ui/components/TracePage/CallIconButton.tsx
+++ b/ui/components/TracePage/CallIconButton.tsx
@@ -17,7 +17,7 @@ export const CallIconButton = forwardRef(
     ref,
   ) => (
     <Button
-      className="rounded-full p-1 h-fit mr-2 !shadow-none hover:bg-slate-200 w-12"
+      className="rounded-full p-1 h-fit mr-2 !shadow-none hover:bg-slate-200 w-fit"
       isActive={expanded}
       {...(isModelCall || !childCount
         ? {}
@@ -30,7 +30,13 @@ export const CallIconButton = forwardRef(
       size="md"
       variant="outline"
     >
-      <span className="mr-1">{isModelCall ? <ChatCenteredDots /> : childCount || "𝑓"}</span>
+      <span
+        className={`h-4 
+        ${isModelCall || childCount == 0 ? "mx-1" : "mr-1 "} 
+        ${childCount == 0 ? "relative bottom-0.5" : ""}`}
+      >
+        {isModelCall ? <ChatCenteredDots /> : childCount || "𝑓"}
+      </span>
     </Button>
   ),
 );

--- a/ui/components/TracePage/CallIconButton.tsx
+++ b/ui/components/TracePage/CallIconButton.tsx
@@ -31,8 +31,8 @@ export const CallIconButton = forwardRef(
       variant="outline"
     >
       <span
-        className={`h-4 
-        ${isModelCall || childCount == 0 ? "mx-1" : "mr-1 "} 
+        className={`h-4
+        ${isModelCall || childCount == 0 ? "mx-1" : "mr-1 "}
         ${childCount == 0 ? "relative bottom-0.5" : ""}`}
       >
         {isModelCall ? <ChatCenteredDots /> : childCount || "𝑓"}


### PR DESCRIPTION
For the Button component, className changed form w-12 to w-fit to allow enough margin numbers with higher digit count. 

<img width="350" alt="image" src="https://github.com/oughtinc/ice/assets/49166991/57890b2b-2cf0-4d8d-9edf-8734d4774b4a">

For elements inside the Button, added h-4 to normalize the height of the button because ChatCenteredDots and "𝑓" have different heights.

When showing  ChatCenteredDots or "𝑓", added mx-1 to add margin and center the element horizontally. 

<img width="350" alt="image" src="https://github.com/oughtinc/ice/assets/49166991/5da71ecf-27ef-4544-a8ff-b3e596d08697">

The "𝑓" symbol itself is not centered vertically (see image in link), added `position: relative;` to center it vertically. 

<img width="350" alt="image" 
src="https://github.com/oughtinc/ice/assets/49166991/d5da90b8-a644-4b7a-be62-a479324d2cb9">

