### PR TITLE
Constrain pydantic < v.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     numerizer
     numpy
     pandas
-    pydantic
+    pydantic < 2
     python-Levenshtein
     python-dotenv
     python-ulid


### PR DESCRIPTION
Fix issue #312 by constraining pydantic < v.2 until a complete migration can be undertaken.

Given the [scope of the backward-incompatible changes in pydantic v2](https://docs.pydantic.dev/latest/migration/), this more targeted fix is likely safer than the fix proposed in #313. 