### PR TITLE
update settings and recipe to pyandtic_settings

### DIFF
--- a/ice/recipe.py
+++ b/ice/recipe.py
@@ -19,7 +19,7 @@ from typing import Union
 import defopt
 import pandas as pd
 from merge_args import merge_args
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from structlog.stdlib import get_logger
 from typing_extensions import TypeGuard
 

--- a/ice/settings.py
+++ b/ice/settings.py
@@ -5,7 +5,7 @@ from typing import Any
 from typing import Optional
 from typing import TYPE_CHECKING
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from structlog import get_logger
 
 from .logging import log_lock


### PR DESCRIPTION
Updates to ice/settings and ice/recipe for fixing Pydantic import error:

```
pydantic.errors.PydanticImportError: `BaseSettings` has been moved to the `pydantic-settings` package. See https://docs.pydantic.dev/2.5/migration/#basesettings-has-moved-to-pydantic-settings for more details.
```